### PR TITLE
Add Sntp_ReceiveTimeResponse API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,17 +17,47 @@ jobs:
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \
           -DBUILD_CLONE_SUBMODULES=ON \
-          -DCMAKE_C_FLAGS='-Wall -Wextra -Werror'
+          -DCMAKE_C_FLAGS='-O0 -Wall -Wextra -Werror -Wformat -Wformat-security -Warray-bounds'
           make -C build/ coverity_analysis -j8
       - name: Build Library in Release mode
         run: |
           rm -rf ./build
+          # Build with logging enabled.
           cmake -S test -B build/ -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Release \
           -DBUILD_CLONE_SUBMODULES=ON \
-          -DCMAKE_C_FLAGS='-Wall -Wextra -Werror -DNDEBUG'
+          -DCMAKE_C_FLAGS='-Wall -Wextra -Werror -DNDEBUG -Wno-error=pedantic -Wno-variadic-macros -DLOGGING_LEVEL_DEBUG=1 -Wformat -Wformat-security -Warray-bounds'
           make -C build/ coverity_analysis -j8
-  unittest-and-coverage:
+  unittest-with-sanitizer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone This Repo
+        uses: actions/checkout@v2
+      - name: Build Library and Unit Tests with Sanitizer
+        run: |
+          CFLAGS="-O0 -Wall -Wexta -Werror"
+          CFLAGS+=" -D_FORTIFY_SOURCE=2"
+          CFLAGS+=" -Wformat"
+          CLFAGS+=" -Wformat-security"
+          CFLAGS+=" -Warray-bounds"
+          CFLAGS+=" -fsanitize=address,undefined"
+          CFLAGS+=" -fsanitize=pointer-compare -fsanitize=pointer-subtract"
+          CFLAGS+=" -fsanitize-recover=undefined"
+          CFLAGS+=" -fsanitize-address-use-after-scope"
+          CFLAGS+=" -fsanitize-undefined-trap-on-error"
+          CFLAGS=" -fstack-protector-all -DLOGGING_LEVEL_DEBUG=1"
+          cmake -S test -B build/ \
+          -G "Unix Makefiles" \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DBUILD_CLONE_SUBMODULES=ON \
+          -DCMAKE_C_FLAGS="${CFLAGS}"
+          make -C build all -j8
+      - name: Run unit tests with sanitizer
+        run: |
+          cd build
+          ctest -E system --output-on-failure
+          cd ..
+  unittest-for-coverage:
     runs-on: ubuntu-latest
     steps:
       - name: Clone This Repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,10 @@ jobs:
       - name: Build Library in Release mode
         run: |
           rm -rf ./build
-          # Build with logging enabled.
           cmake -S test -B build/ -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Release \
           -DBUILD_CLONE_SUBMODULES=ON \
-          -DCMAKE_C_FLAGS='-Wall -Wextra -Werror -DNDEBUG -Wno-error=pedantic -Wno-variadic-macros -DLOGGING_LEVEL_DEBUG=1 -Wformat -Wformat-security -Warray-bounds'
+          -DCMAKE_C_FLAGS='-Wall -Wextra -Werror -DNDEBUG -Wformat -Wformat-security -Warray-bounds -D_FORTIFY_SOURCE=1'
           make -C build/ coverity_analysis -j8
   unittest-with-sanitizer:
     runs-on: ubuntu-latest
@@ -65,6 +64,7 @@ jobs:
       - name: Build
         run: |
           sudo apt-get install -y lcov sed
+          # Build with logging enabled.
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           cmake -S test -B build/ -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Release \
           -DBUILD_CLONE_SUBMODULES=ON \
-          -DCMAKE_C_FLAGS='-Wall -Wextra -Werror -DNDEBUG -Wformat -Wformat-security -Warray-bounds -D_FORTIFY_SOURCE=1'
+          -DCMAKE_C_FLAGS='-Wall -Wextra -Werror -DNDEBUG -Wformat -Wformat-security -Warray-bounds'
           make -C build/ coverity_analysis -j8
   unittest-with-sanitizer:
     runs-on: ubuntu-latest

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -5,9 +5,11 @@ apis
 ascii
 auth
 authcodesize
+authintf
 aws
 backoff
 beforelooptime
+blocktimems
 br
 buffersize
 bytesremaining
@@ -29,6 +31,8 @@ currenttimelist
 de
 deamon
 december
+deserialize
+deserializer
 deserializeresponse
 desiredaccuracy
 dns
@@ -65,6 +69,7 @@ jan
 january
 june
 kod
+leapsecondinfo
 leapversionmode
 lsb
 misra
@@ -118,6 +123,7 @@ psntptime
 ptimeserver
 ptimeservers
 ptr
+ptransportintf
 pudptransportintf
 punixtimemicrosecs
 punixtimesecs
@@ -149,6 +155,7 @@ serializerequest
 serveraddr
 servernamelen
 serverport
+serverresponsetimeoutms
 setsystemtimefunc
 sizeof
 sntp
@@ -161,8 +168,11 @@ sntperrorbuffertoosmall
 sntperrorchangeserver
 sntperrordnsfailure
 sntperrornetworkfailure
+sntperrorresponsetimeout
 sntperrortimenotsupported
 sntpinvalidresponse
+sntpnoresponse
+sntprejectedresponse
 sntprejectedresponsechangeserver
 sntprejectedresponseothercode
 sntprejectedresponseretrywithbackoff
@@ -182,10 +192,12 @@ transmittime
 trng
 tx
 udp
+udprecvretcodes
 udpsendretcodes
 uint
 unix
 utc
+validateserverauth
 wordmemory
 wordval
 www

--- a/source/core_sntp_client.c
+++ b/source/core_sntp_client.c
@@ -571,8 +571,7 @@ static SntpStatus_t processServerResponse( SntpContext_t * pContext,
         }
         else
         {
-            LogDebug( ( "Server response has been validated: Server=%.*s",
-                        ( int ) pServer->serverNameLen, pServer->pServerName ) );
+            LogDebug( ( "Server response has been validated: Server=%.*s", ( int ) pServer->serverNameLen, pServer->pServerName ) );
         }
     }
 

--- a/source/core_sntp_client.c
+++ b/source/core_sntp_client.c
@@ -571,7 +571,7 @@ static SntpStatus_t processServerResponse( SntpContext_t * pContext,
         }
         else
         {
-            LogDebug( ( "Server response has been validated: Server=%.s",
+            LogDebug( ( "Server response has been validated: Server=%.*s",
                         ( int ) pServer->serverNameLen, pServer->pServerName ) );
         }
     }
@@ -598,7 +598,7 @@ static SntpStatus_t processServerResponse( SntpContext_t * pContext,
             pContext->currentServerIndex++;
 
             LogError( ( "Unable to use server response: Server has rejected request for time: RejectionCode=%.*s",
-                        ( int ) SNTP_KISS_OF_DEATH_CODE_LENGTH, parsedResponse.rejectedResponseCode ) );
+                        ( int ) SNTP_KISS_OF_DEATH_CODE_LENGTH, ( char * ) &parsedResponse.rejectedResponseCode ) );
             status = SntpRejectedResponse;
         }
         else if( status == SntpInvalidResponse )

--- a/source/core_sntp_client.c
+++ b/source/core_sntp_client.c
@@ -642,7 +642,7 @@ SntpStatus_t Sntp_ReceiveTimeResponse( SntpContext_t * pContext,
         LogError( ( "Invalid context parameter: Context cannot be NULL" ) );
     }
 
-    /* Check whether there is any remaining server to in the list of configured
+    /* Check whether there is any remaining server in the list of configured
      * servers that it is reasonable to expect a response from. */
     else if( pContext->currentServerIndex >= pContext->numOfServers )
     {

--- a/source/core_sntp_client.c
+++ b/source/core_sntp_client.c
@@ -32,6 +32,14 @@
 /* SNTP client library API include. */
 #include "core_sntp_client.h"
 
+/**
+ * @brief Utility to convert fractions part of SNTP timestamp to milliseconds.
+ *
+ * @param[in] fractions The fractions value in an SNTP timestamp.
+ */
+#define FRACTIONS_TO_MS( fractions ) \
+    ( fractions / ( SNTP_FRACTION_VALUE_PER_MICROSECOND * 1000U ) )
+
 SntpStatus_t Sntp_Init( SntpContext_t * pContext,
                         const SntpServerInfo_t * pTimeServers,
                         size_t numOfServers,
@@ -194,7 +202,7 @@ static SntpStatus_t sendSntpPacket( const UdpTransportInterface_t * pNetworkIntf
 {
     const uint8_t * pIndex = pPacket;
     size_t bytesRemaining = packetSize;
-    int32_t totalBytesSent = 0, bytesSent = 0;
+    int32_t bytesSent = 0;
     SntpTimestamp_t lastSendTime;
     uint32_t timeSinceLastSendMs;
     bool sendError = false;
@@ -221,7 +229,6 @@ static SntpStatus_t sendSntpPacket( const UdpTransportInterface_t * pNetworkIntf
         {
             LogError( ( "Unable to send request packet: Transport send failed. "
                         "ErrorCode=%ld.", ( long int ) bytesSent ) );
-            totalBytesSent = bytesSent;
             sendError = true;
         }
         else if( bytesSent > 0 )
@@ -236,7 +243,6 @@ static SntpStatus_t sendSntpPacket( const UdpTransportInterface_t * pNetworkIntf
             assert( ( size_t ) bytesSent <= bytesRemaining );
 
             bytesRemaining -= ( size_t ) bytesSent;
-            totalBytesSent += bytesSent;
             pIndex += bytesSent;
             LogDebug( ( "BytesSent=%d, BytesRemaining=%lu", bytesSent, bytesRemaining ) );
         }
@@ -370,8 +376,8 @@ SntpStatus_t Sntp_SendTimeRequest( SntpContext_t * pContext,
             /* Obtain current system time to generate SNTP request packet. */
             pContext->getTimeFunc( &pContext->lastRequestTime );
 
-            LogDebug( ( "Obtained current time for SNTP request packet: Seconds=%u, Fractions=%u",
-                        pContext->lastRequestTime.seconds, pContext->lastRequestTime.fractions ) );
+            LogDebug( ( "Obtained current time for SNTP request packet: Time=%us %ums",
+                        pContext->lastRequestTime.seconds, FRACTIONS_TO_MS( pContext->lastRequestTime.fractions ) ) );
 
             /* Generate SNTP request packet with the current system time and
              * the passed random number. */
@@ -411,30 +417,209 @@ SntpStatus_t Sntp_SendTimeRequest( SntpContext_t * pContext,
     return status;
 }
 
+/**
+ * @brief This function attempts to receive the SNTP response packet from a server
+ * if the time window for server response has not timed out.
+ *
+ * @note This function does not block on receiving the response packet from the network.
+ * Instead, it determines whether the response packet is already available on the network
+ * by first reading ONLY a single byte of data first.
+ * If the single byte is available from the network, then rest of the SNTP response packet is
+ * read from the network with retries for zero or partial reads until either:
+ * - All the remaining bytes of server response are received
+ *                     OR
+ * - A timeout of #SNTP_RECV_POLLING_TIMEOUT_MS occurs of receiving no data over the network.
+ *
+ * @param[in] pTransportIntf The UDP transport interface to use for receiving data from
+ * the network.
+ * @param[in] timeServer The server to read the response from the network.
+ * @param[in] serverPort The port of the server to read the response from.
+ * @param[in, out] pBuffer This will be filled with the server response read from the
+ * network.
+ * @param[in] responseSize The size of server response to read from the network.
+ * @param[in] getTimeFunc The interface for obtaining system time.
+ *
+ * @return It returns one of the following:
+ * - #SntpSuccess if an SNTP response packet is received from the network.
+ * - #SntpNoResponse if a server response is not received from the network.
+ * - #SntpErrorNetworkFailure if there is an internal failure in reading from the network
+ * in the user-defined transport interface.
+ */
 static SntpStatus_t receiveSntpResponse( const UdpTransportInterface_t * pTransportIntf,
                                          uint32_t timeServer,
                                          uint16_t serverPort,
-                                         const uint8_t * pBuffer,
+                                         uint8_t * pBuffer,
                                          size_t responseSize,
-                                         const SntpTimestamp_t * pRequestTime,
-                                         uint32_t responseTimeoutMs,
                                          SntpGetTime_t getTimeFunc )
 {
     SntpStatus_t status = SntpSuccess;
-
     SntpTimestamp_t startTime;
+    int32_t bytesRead = 0;
 
     getTimeFunc( &startTime );
 
-    /* Check whether a response timeout has occurred. */
-    while( calculateElapsedTimeMs( &startTime, pRequestTime ) >= responseTimeoutMs )
+    /* Check whether there is any data available on the network to read by attempting to read
+     * a single byte. */
+    bytesRead = pTransportIntf->recvFrom( pTransportIntf->pUserContext,
+                                          timeServer,
+                                          serverPort,
+                                          pBuffer,
+                                          1U );
+
+    if( bytesRead == 1 )
     {
-        status = SntpErrorResponseTimeout;
-        LogError( ( "Unable to receive response: Server response has timed out: "
-                    "RequestTime=%us %ums, TimeoutDuration=%u",
-                    pRequestTime->seconds,
-                    pRequestTime->fractions / ( SNTP_FRACTION_VALUE_PER_MICROSECOND * 1000 ),
-                    responseTimeoutMs ) );
+        size_t bytesRemaining = responseSize - 1U;
+
+        while( ( bytesRemaining > 0U ) && ( status == SntpSuccess ) )
+        {
+            bytesRead = pTransportIntf->recvFrom( pTransportIntf->pUserContext,
+                                                  timeServer,
+                                                  serverPort,
+                                                  pBuffer,
+                                                  1U );
+
+            if( bytesRead > 0 )
+            {
+                bytesRemaining -= ( size_t ) bytesRead;
+
+                /* Read the current system time to set it as the new base line
+                 * for evaluating the receive retry timeout, #SNTP_RECV_POLLING_TIMEOUT_MS.*/
+                getTimeFunc( &startTime );
+            }
+            else if( bytesRead == 0 )
+            {
+                SntpTimestamp_t currentTime;
+                uint32_t timeSinceLastRecv = calculateElapsedTimeMs( &currentTime, &startTime );
+
+                if( timeSinceLastRecv >= SNTP_RECV_POLLING_TIMEOUT_MS )
+                {
+                    LogError( ( "Unable to receive server response: Timed out retrying reads: Timeout=%ums", SNTP_RECV_POLLING_TIMEOUT_MS ) );
+                    status = SntpErrorNetworkFailure;
+                }
+            }
+            else
+            {
+                status = SntpErrorNetworkFailure;
+            }
+        }
+    }
+    else if( bytesRead == 0 )
+    {
+        LogDebug( ( "No data available on the network to read." ) );
+        status = SntpNoResponseReceived;
+    }
+
+    if( bytesRead < 0 )
+    {
+        status = SntpErrorNetworkFailure;
+        LogError( ( "Unable to receive server response: Transport receive failed: Code=%ld",
+                    ( long int ) bytesRead ) );
+    }
+
+    return status;
+}
+
+/**
+ * @brief Processes the response from a server by de-serializing the SNTP packet to
+ * validate the server (if an authentication interface has been configured), determine
+ * whether server has accepted or rejected the time request, and update the system clock
+ * if the server responded positively with time.
+ *
+ * @param[in] pContext The SNTP context representing the SNTP client.
+ * @param[in] pResponseRxTime The time of receiving the server response from the network.
+ *
+ * @return It returns one of the following:
+ * - #SntpSuccess if the server response is successfully de-serialized and system clock
+ * updated.
+ * - #SntpErrorAuthFailure if there is internal failure in user-defined authentication
+ * interface when validating server from the response.
+ * - #SntpServerNotAuthenticated if the server failed authenticated check in the user-defined
+ * interface.
+ * - #SntpRejectedResponse if the server has rejected the time request in its response.
+ * - #SntpInvalidResponse if the server response failed sanity checks.
+ */
+static SntpStatus_t processServerResponse( SntpContext_t * pContext,
+                                           SntpTimestamp_t * pResponseRxTime )
+{
+    SntpStatus_t status = SntpSuccess;
+    const SntpServerInfo_t * pServer = &pContext->pTimeServers[ pContext->currentServerIndex ];
+
+    assert( pContext != NULL );
+    assert( pResponseRxTime != NULL );
+
+    if( pContext->authIntf.validateServerAuth != NULL )
+    {
+        /* Verify the server from the authentication data in the SNTP response packet. */
+        status = pContext->authIntf.validateServerAuth( pContext->authIntf.pAuthContext,
+                                                        pServer,
+                                                        pContext->pNetworkBuffer,
+                                                        pContext->bufferSize );
+        assert( ( status == SntpSuccess ) || ( status == SntpErrorAuthFailure ) ||
+                ( status == SntpServerNotAuthenticated ) );
+
+        if( status != SntpSuccess )
+        {
+            LogError( ( "Unable to use server response: Server authentication function failed: "
+                        "ReturnStatus=%s", Sntp_StatusToStr( status ) ) );
+        }
+        else
+        {
+            LogDebug( ( "Server response has been validated: Server=%.s",
+                        ( int ) pServer->serverNameLen, pServer->pServerName ) );
+        }
+    }
+
+    if( status == SntpSuccess )
+    {
+        SntpResponseData_t parsedResponse;
+
+        /* De-serialize response packet to determine whether the server accepted or rejected
+         * the request for time. Also, calculate the system clock offset if the server responded
+         * with time. */
+        status = Sntp_DeserializeResponse( &pContext->lastRequestTime,
+                                           pResponseRxTime,
+                                           pContext->pNetworkBuffer,
+                                           pContext->bufferSize,
+                                           &parsedResponse );
+
+        if( ( status == SntpRejectedResponseChangeServer ) ||
+            ( status == SntpRejectedResponseRetryWithBackoff ) ||
+            ( status == SntpRejectedResponseOtherCode ) )
+        {
+            /* Server has rejected the time request. Thus, we will rotate to the next time server
+            * in the list, if we have not exhausted time requests with all configured servers. */
+            pContext->currentServerIndex++;
+
+            LogError( ( "Unable to use server response: Server has rejected request for time: RejectionCode=%.*s",
+                        ( int ) SNTP_KISS_OF_DEATH_CODE_LENGTH, parsedResponse.rejectedResponseCode ) );
+            status = SntpRejectedResponse;
+        }
+        else if( status == SntpInvalidResponse )
+        {
+            LogError( ( "Unable to use server response: Server response failed sanity checks." ) );
+        }
+        else
+        {
+            /* If the system clock is not within 34 years of server time, clock offset value cannot be
+             * calculated. This case is only treated as a warning instead of an error because one the system
+             * clock is updated with the time from server, the issue will be resolved for time queries. */
+            if( status == SntpClockOffsetOverflow )
+            {
+                LogWarn( ( "Failed to calculate clock offset: System time SHOULD be within 34 years of server time." ) );
+            }
+
+            /* Server has responded successfully with time, and we have calculated the clock offset
+             * of system clock relative to the server.*/
+            LogDebug( ( "Updating system time: ServerTime=%u %ums ClockOffset=%us",
+                        parsedResponse.serverTime.seconds, FRACTIONS_TO_MS( parsedResponse.serverTime.fractions ),
+                        parsedResponse.clockOffsetSec ) );
+
+            /* Update the system clock with the calculated offset. */
+            pContext->setTimeFunc( pServer, &parsedResponse.serverTime,
+                                   parsedResponse.clockOffsetSec, parsedResponse.leapSecondType );
+
+            status = SntpSuccess;
+        }
     }
 
     return status;
@@ -443,7 +628,7 @@ static SntpStatus_t receiveSntpResponse( const UdpTransportInterface_t * pTransp
 SntpStatus_t Sntp_ReceiveTimeResponse( SntpContext_t * pContext,
                                        uint32_t blockTimeMs )
 {
-    SntpStatus_t status = SntpSuccess;
+    SntpStatus_t status = SntpNoResponseReceived;
 
     if( pContext == NULL )
     {
@@ -453,13 +638,42 @@ SntpStatus_t Sntp_ReceiveTimeResponse( SntpContext_t * pContext,
     else
     {
         SntpTimestamp_t startTime, loopIterTime;
-        bool responseReceived = false;
-
         pContext->getTimeFunc( &startTime );
 
         do
         {
-        } while( ( responseReceived == false ) &&
+            status = receiveSntpResponse( &pContext->networkIntf,
+                                          pContext->currentServerAddr,
+                                          pContext->pTimeServers[ pContext->currentServerIndex ].port,
+                                          pContext->pNetworkBuffer,
+                                          pContext->bufferSize,
+                                          pContext->getTimeFunc );
+
+            /* Get current time to either de-serialize the SNTP packet if a server response has been
+             * received OR utilize for determining whether another attempt for reading the packet can
+             * be made. */
+            pContext->getTimeFunc( &loopIterTime );
+
+            /* If the server response is received, deserialize it, validate the server
+             * (if authentication interface is provided), and update system time with
+             * the calculated clock offset. */
+            if( status == SntpSuccess )
+            {
+                status = processServerResponse( pContext, &loopIterTime );
+            }
+
+            /* Check whether a response timeout has occurred before re-trying the
+             * read in the next iteration. */
+            else if( calculateElapsedTimeMs( &loopIterTime, &pContext->lastRequestTime )
+                     >= pContext->responseTimeoutMs )
+            {
+                status = SntpErrorResponseTimeout;
+                LogError( ( "Unable to receive response: Server response has timed out: "
+                            "RequestTime=%us %ums, TimeoutDuration=%u", pContext->lastRequestTime.seconds,
+                            FRACTIONS_TO_MS( pContext->lastRequestTime.fractions ),
+                            pContext->responseTimeoutMs ) );
+            }
+        } while( ( status == SntpNoResponseReceived ) &&
                  ( calculateElapsedTimeMs( &loopIterTime, &startTime ) < blockTimeMs ) );
     }
 

--- a/source/core_sntp_client.c
+++ b/source/core_sntp_client.c
@@ -492,7 +492,11 @@ static SntpStatus_t receiveSntpResponse( const UdpTransportInterface_t * pTransp
             else if( bytesRead == 0 )
             {
                 SntpTimestamp_t currentTime;
-                uint32_t timeSinceLastRecv = calculateElapsedTimeMs( &currentTime, &startTime );
+                uint32_t timeSinceLastRecv = 0;
+
+                getTimeFunc( &currentTime );
+
+                timeSinceLastRecv = calculateElapsedTimeMs( &currentTime, &startTime );
 
                 if( timeSinceLastRecv >= SNTP_RECV_POLLING_TIMEOUT_MS )
                 {

--- a/source/include/core_sntp_client.h
+++ b/source/include/core_sntp_client.h
@@ -129,11 +129,8 @@ typedef void ( * SntpGetTime_t )( SntpTimestamp_t * pCurrentTime );
  * the "step" discipline methodology can be used to directly update the system
  * clock with the current server time, @p pServerTime, every time the coreSNTP
  * library calls the interface.
- *
- * @return `true` if setting system time is successful; otherwise `false` to
- * represent failure.
  */
-typedef bool ( * SntpSetTime_t )( const SntpServerInfo_t * pTimeServer,
+typedef void ( * SntpSetTime_t )( const SntpServerInfo_t * pTimeServer,
                                   const SntpTimestamp_t * pServerTime,
                                   int32_t clockOffsetSec );
 
@@ -306,10 +303,10 @@ typedef SntpStatus_t (* SntpGenerateAuthCode_t )( SntpAuthContext_t * pContext,
  * - #SntpErrorAuthFailure for failure to authenticate server due to internal
  * error.
  */
-typedef SntpStatus_t (* SntpValidateAuthCode_t )( SntpAuthContext_t * pContext,
-                                                  const SntpServerInfo_t * pTimeServer,
-                                                  const void * pResponseData,
-                                                  size_t responseSize );
+typedef SntpStatus_t (* SntpValidateServerAuth_t )( SntpAuthContext_t * pContext,
+                                                    const SntpServerInfo_t * pTimeServer,
+                                                    const void * pResponseData,
+                                                    size_t responseSize );
 
 /**
  * @ingroup core_sntp_struct_types
@@ -338,7 +335,7 @@ typedef struct SntpAuthenticationIntf
      * @brief The user-defined function to authenticating server from its SNTP
      * response.
      */
-    SntpValidateAuthCode_t validateServerAuth;
+    SntpValidateServerAuth_t validateServerAuth;
 } SntpAuthenticationInterface_t;
 
 /**
@@ -435,6 +432,13 @@ typedef struct SntpContext
      * from the server.
      */
     size_t sntpPacketSize;
+
+    /**
+     * @brief The timeout duration (in milliseconds) for receiving a response, through
+     * @ref Sntp_ReceiveTimeResponse API, from a server after the request for time is
+     * sent to it through @ref Sntp_SendTimeRequest API.
+     */
+    uint32_t responseTimeoutMs;
 } SntpContext_t;
 
 /**
@@ -447,6 +451,9 @@ typedef struct SntpContext
  * servers that should be used by the SNTP client. This list MUST stay in
  * scope for all the time of use of the context.
  * @param[in] numOfServers The number of servers in the list, @p pTimeServers.
+ * @param[in] serverResponseTimeoutMs The timeout duration (in milliseconds) for
+ * receiving server response for time requests. The same timeout value is used for
+ * each server in the @p pTimeServers list.
  * @param[in] pNetworkBuffer The user-supplied memory that will be used for
  * storing network data for SNTP client-server communication. The buffer
  * MUST stay in scope for all the time of use of the context.
@@ -480,6 +487,7 @@ typedef struct SntpContext
 SntpStatus_t Sntp_Init( SntpContext_t * pContext,
                         const SntpServerInfo_t * pTimeServers,
                         size_t numOfServers,
+                        uint32_t serverResponseTimeoutMs,
                         uint8_t * pNetworkBuffer,
                         size_t bufferSize,
                         SntpResolveDns_t resolveDnsFunc,
@@ -512,7 +520,7 @@ SntpStatus_t Sntp_Init( SntpContext_t * pContext,
  * @return The API function returns one of the following:
  *  - #SntpSuccess if a time request is successfully sent to the currently configured
  * time server in the context.
- *  - #SntpErrorBadParameter if any invalid parameter is passed to the function.
+ *  - #SntpErrorBadParameter if an invalid context is passed to the function.
  *  - #SntpErrorChangeServer if there is no server remaining in the list of configured
  * servers that has not rejected a prior time request.
  *  - #SntpErrorDnsFailure if there is failure in the user-defined function for
@@ -526,6 +534,51 @@ SntpStatus_t Sntp_Init( SntpContext_t * pContext,
 SntpStatus_t Sntp_SendTimeRequest( SntpContext_t * pContext,
                                    uint32_t randomNumber );
 /* @[define_sntp_sendtimerequest] */
+
+
+/**
+ * @brief Receives a time response from the server that has been requested for time with
+ * the @ref Sntp_SendTimeRequest API function.
+ * Once an accepted response containing time from server is received, this function calls
+ * the user-defined @ref SntpSetTime_t function to update the system time.
+ *
+ * @note If the user has provided an authentication interface to the client
+ * (through @ref Sntp_Init), the server response is authenticated by calling the
+ * @ref SntpValidateServerAuth_t function of the @ref SntpAuthenticationInterface_t interface.
+ *
+ * @note This API will rotate the server of use in the library for the next time request
+ * (through the @ref Sntp_SendTimeRequest) if either of following events occur:
+ *  - The server has responded with a rejection for the time request.
+ *                         OR
+ *  - The server response wait has timed out.
+ *
+ * @param[in] pContext The context representing an SNTPv4 client.
+ * @param[in] blockTimeMs The maximum duration of time the function will block on
+ * receiving a response from the server unless either the response is received
+ * OR a response timeout occurs.
+ *
+ * @note This function can be called multiple times with zero or small blocking times
+ * to poll whether server response is received until either the response response is
+ * received from the server OR a response timeout has occurred.
+ *
+ * @return This API functions returns one of the following:
+ *  - #SntpSuccess if a successful server response is received.
+ *  - #SntpErrorBadParameter if an invalid context is passed to the function.
+ *  - #SntpErrorNetworkFailure if there is a failure in the user-defined transport
+ *  - #SntpErrorAuthFailure if an internal error occurs in the user-defined
+ * authentication interface when validating the server response.
+ * receive interface in receiving server response from the network.
+ *  - #SntpServerNotAuthenticated when the server could not be authenticated from
+ * its response with the user-defined authentication interface.
+ * - #SntpErrorResponseTimeout if a timeout has occurred in receiving response from
+ * the server.
+ * - #SntpRejectedResponse if the server responded with a rejection for the time
+ * request.
+ */
+/* @[define_sntp_receivetimeresponse] */
+SntpStatus_t Sntp_ReceiveTimeResponse( SntpContext_t * pContext,
+                                       uint32_t blockTimeMs );
+/* @[define_sntp_receivetimeresponse] */
 
 /**
  * @brief Converts @ref SntpStatus_t to its equivalent

--- a/source/include/core_sntp_client.h
+++ b/source/include/core_sntp_client.h
@@ -578,6 +578,9 @@ SntpStatus_t Sntp_SendTimeRequest( SntpContext_t * pContext,
  * @return This API functions returns one of the following:
  *  - #SntpSuccess if a successful server response is received.
  *  - #SntpErrorBadParameter if an invalid context is passed to the function.
+ *  - #SntpErrorChangeServer if all servers configured in the context have already
+ * rejected time requests in previous attempts, and application SHOULD change server(s)
+ * for future time requests with the @ref Sntp_Init API.
  *  - #SntpErrorNetworkFailure if there is a failure in the user-defined transport
  *  - #SntpErrorAuthFailure if an internal error occurs in the user-defined
  * authentication interface when validating the server response.

--- a/source/include/core_sntp_serializer.h
+++ b/source/include/core_sntp_serializer.h
@@ -248,7 +248,13 @@ typedef enum SntpStatus
      * @brief A timeout has occurred in receiving server response with the @ref Sntp_ReceiveTimeResponse
      * API.
      */
-    SntpErrorResponseTimeout
+    SntpErrorResponseTimeout,
+
+    /**
+     * @brief No SNTP packet for server response is received from the network by the
+     * @ref Sntp_ReceiveTimeResponse API.
+     */
+    SntpNoResponseReceived
 } SntpStatus_t;
 
 /**
@@ -400,8 +406,8 @@ SntpStatus_t Sntp_SerializeRequest( SntpTimestamp_t * pRequestTime,
  * @note If the server has positively responded with its clock time, then this API
  * function will calculate the clock-offset ONLY if the system clock is within
  * 34 years of the server time mentioned in the response packet; otherwise the
- * seconds part of the clock offset in @p pParsedResponse parameter will be set to
- * #SNTP_CLOCK_OFFSET_OVERFLOW, and the function will return #SntpClockOffsetOverflow.
+ * the clock offset in @p pParsedResponse parameter will be set to #SNTP_CLOCK_OFFSET_OVERFLOW,
+ * and the function will return #SntpClockOffsetOverflow.
  *
  * @param[in] pRequestTime The system time used in the SNTP request packet
  * that is associated with the server response. This MUST be the same as the

--- a/source/include/core_sntp_serializer.h
+++ b/source/include/core_sntp_serializer.h
@@ -154,6 +154,12 @@ typedef enum SntpStatus
     SntpErrorBadParameter,
 
     /**
+     * @brief Server sent a Kiss-o'-Death message to reject the request for time.
+     * This status can be returned by the @ref Sntp_ReceiveTimeResponse API.
+     */
+    SntpRejectedResponse,
+
+    /**
      * @brief Server sent a Kiss-o'-Death message with non-retryable code (i.e. DENY or RSTR).
      */
     SntpRejectedResponseChangeServer,
@@ -227,7 +233,7 @@ typedef enum SntpStatus
     /**
      * @brief Time server is not authenticated from the authentication data in its response.
      * This status can be returned by the user-supplied definition of the
-     * @ref SntpValidateAuthCode_t authentication interface.
+     * @ref SntpValidateServerAuth_t authentication interface.
      */
     SntpServerNotAuthenticated,
 
@@ -236,7 +242,13 @@ typedef enum SntpStatus
      * in either generating authentication data for SNTP request OR validating the authentication
      * data in SNTP response from server.
      */
-    SntpErrorAuthFailure
+    SntpErrorAuthFailure,
+
+    /**
+     * @brief A timeout has occurred in receiving server response with the @ref Sntp_ReceiveTimeResponse
+     * API.
+     */
+    SntpErrorResponseTimeout
 } SntpStatus_t;
 
 /**

--- a/test/unit-test/core_sntp_client_utest.c
+++ b/test/unit-test/core_sntp_client_utest.c
@@ -128,11 +128,14 @@ void getTime( SntpTimestamp_t * pCurrentTime )
 /* Test definition of the @ref SntpSetTime_t interface. */
 void setTime( const SntpServerInfo_t * pTimeServer,
               const SntpTimestamp_t * pServerTime,
-              int32_t clockOffsetSec )
+              int32_t clockOffsetSec,
+              SntpLeapSecondInfo_t leapSecondInfo )
 {
     TEST_ASSERT_NOT_NULL( pTimeServer );
     TEST_ASSERT_NOT_NULL( pServerTime );
+
     ( void ) clockOffsetSec;
+    ( void ) leapSecondInfo;
 }
 
 /* Test definition of the @ref UdpTransportSendTo_t interface. */
@@ -490,6 +493,7 @@ void test_Init_Nominal( void )
         TEST_ASSERT_EQUAL( testServers, context.pTimeServers );                                                \
         TEST_ASSERT_EQUAL( sizeof( testServers ) / sizeof( SntpServerInfo_t ), context.numOfServers );         \
         TEST_ASSERT_EQUAL_PTR( testBuffer, context.pNetworkBuffer );                                           \
+        TEST_ASSERT_EQUAL( TEST_RESPONSE_TIMEOUT, context.responseTimeoutMs );                                 \
         TEST_ASSERT_EQUAL( sizeof( testBuffer ), context.bufferSize );                                         \
         TEST_ASSERT_EQUAL_PTR( dnsResolve, context.resolveDnsFunc );                                           \
         TEST_ASSERT_EQUAL_PTR( getTime, context.getTimeFunc );                                                 \

--- a/test/unit-test/core_sntp_client_utest.c
+++ b/test/unit-test/core_sntp_client_utest.c
@@ -41,7 +41,9 @@
 #include "mock_core_sntp_serializer.h"
 
 /* Test IPv4 address for time server. */
-#define TEST_SERVER_ADDR    ( 0xAABBCCDD )
+#define TEST_SERVER_ADDR         ( 0xAABBCCDD )
+
+#define TEST_RESPONSE_TIMEOUT    ( 1000 )
 
 /* Utility to convert milliseconds to fractions value in
  * SNTP timestamp. */
@@ -86,7 +88,6 @@ static bool dnsResolveRetCode = true;
 static uint32_t dnsResolveAddr = TEST_SERVER_ADDR;
 static SntpTimestamp_t currentTimeList[ 4 ];
 static uint8_t currentTimeIndex;
-static bool setTimeRetCode = true;
 static size_t expectedBytesToSend = SNTP_PACKET_BASE_SIZE;
 static int32_t udpSendRetCodes[ 2 ];
 static uint8_t currentUdpSendCodeIndex;
@@ -125,15 +126,13 @@ void getTime( SntpTimestamp_t * pCurrentTime )
 }
 
 /* Test definition of the @ref SntpSetTime_t interface. */
-bool setTime( const SntpServerInfo_t * pTimeServer,
+void setTime( const SntpServerInfo_t * pTimeServer,
               const SntpTimestamp_t * pServerTime,
               int32_t clockOffsetSec )
 {
     TEST_ASSERT_NOT_NULL( pTimeServer );
     TEST_ASSERT_NOT_NULL( pServerTime );
     ( void ) clockOffsetSec;
-
-    return setTimeRetCode;
 }
 
 /* Test definition of the @ref UdpTransportSendTo_t interface. */
@@ -206,7 +205,7 @@ SntpStatus_t generateClientAuth( SntpAuthContext_t * pContext,
     return generateClientAuthRetCode;
 }
 
-/* Test definition for @ref SntpValidateAuthCode_t interface. */
+/* Test definition for @ref SntpValidateServerAuth_t interface. */
 SntpStatus_t validateServerAuth( SntpAuthContext_t * pContext,
                                  const SntpServerInfo_t * pTimeServer,
                                  const void * pResponseData,
@@ -228,7 +227,6 @@ void setUp()
     /* Reset the global variables. */
     dnsResolveRetCode = true;
     dnsResolveAddr = TEST_SERVER_ADDR;
-    setTimeRetCode = true;
     udpRecvCode = 0;
     generateClientAuthRetCode = SntpSuccess;
     validateServerAuthRetCode = SntpSuccess;
@@ -261,6 +259,7 @@ void setUp()
                        Sntp_Init( &context,
                                   testServers,
                                   sizeof( testServers ) / sizeof( SntpServerInfo_t ),
+                                  TEST_RESPONSE_TIMEOUT,
                                   testBuffer,
                                   sizeof( testBuffer ),
                                   dnsResolve,
@@ -293,6 +292,7 @@ void test_Init_InvalidParams( void )
                        Sntp_Init( NULL,
                                   testServers,
                                   sizeof( testServers ) / sizeof( SntpServerInfo_t ),
+                                  TEST_RESPONSE_TIMEOUT,
                                   testBuffer,
                                   sizeof( testBuffer ),
                                   dnsResolve,
@@ -306,6 +306,7 @@ void test_Init_InvalidParams( void )
                        Sntp_Init( &context,
                                   NULL,
                                   sizeof( testServers ) / sizeof( SntpServerInfo_t ),
+                                  TEST_RESPONSE_TIMEOUT,
                                   testBuffer,
                                   sizeof( testBuffer ),
                                   dnsResolve,
@@ -317,6 +318,7 @@ void test_Init_InvalidParams( void )
                        Sntp_Init( &context,
                                   testServers,
                                   0,
+                                  TEST_RESPONSE_TIMEOUT,
                                   testBuffer,
                                   sizeof( testBuffer ),
                                   dnsResolve,
@@ -330,6 +332,7 @@ void test_Init_InvalidParams( void )
                        Sntp_Init( &context,
                                   testServers,
                                   sizeof( testServers ) / sizeof( SntpServerInfo_t ),
+                                  TEST_RESPONSE_TIMEOUT,
                                   NULL,
                                   sizeof( testBuffer ),
                                   dnsResolve,
@@ -341,6 +344,7 @@ void test_Init_InvalidParams( void )
                        Sntp_Init( &context,
                                   testServers,
                                   sizeof( testServers ) / sizeof( SntpServerInfo_t ),
+                                  TEST_RESPONSE_TIMEOUT,
                                   testBuffer,
                                   SNTP_PACKET_BASE_SIZE / 2,
                                   dnsResolve,
@@ -354,6 +358,7 @@ void test_Init_InvalidParams( void )
                        Sntp_Init( &context,
                                   testServers,
                                   sizeof( testServers ) / sizeof( SntpServerInfo_t ),
+                                  TEST_RESPONSE_TIMEOUT,
                                   testBuffer,
                                   sizeof( testBuffer ),
                                   NULL,
@@ -365,6 +370,7 @@ void test_Init_InvalidParams( void )
                        Sntp_Init( &context,
                                   testServers,
                                   sizeof( testServers ) / sizeof( SntpServerInfo_t ),
+                                  TEST_RESPONSE_TIMEOUT,
                                   testBuffer,
                                   sizeof( testBuffer ),
                                   dnsResolve,
@@ -376,6 +382,7 @@ void test_Init_InvalidParams( void )
                        Sntp_Init( &context,
                                   testServers,
                                   sizeof( testServers ) / sizeof( SntpServerInfo_t ),
+                                  TEST_RESPONSE_TIMEOUT,
                                   testBuffer,
                                   sizeof( testBuffer ),
                                   dnsResolve,
@@ -387,6 +394,7 @@ void test_Init_InvalidParams( void )
                        Sntp_Init( &context,
                                   testServers,
                                   sizeof( testServers ) / sizeof( SntpServerInfo_t ),
+                                  TEST_RESPONSE_TIMEOUT,
                                   testBuffer,
                                   sizeof( testBuffer ),
                                   dnsResolve,
@@ -401,6 +409,7 @@ void test_Init_InvalidParams( void )
                        Sntp_Init( &context,
                                   testServers,
                                   sizeof( testServers ) / sizeof( SntpServerInfo_t ),
+                                  TEST_RESPONSE_TIMEOUT,
                                   testBuffer,
                                   sizeof( testBuffer ),
                                   dnsResolve,
@@ -414,6 +423,7 @@ void test_Init_InvalidParams( void )
                        Sntp_Init( &context,
                                   testServers,
                                   sizeof( testServers ) / sizeof( SntpServerInfo_t ),
+                                  TEST_RESPONSE_TIMEOUT,
                                   testBuffer,
                                   sizeof( testBuffer ),
                                   dnsResolve,
@@ -431,6 +441,7 @@ void test_Init_InvalidParams( void )
                        Sntp_Init( &context,
                                   testServers,
                                   sizeof( testServers ) / sizeof( SntpServerInfo_t ),
+                                  TEST_RESPONSE_TIMEOUT,
                                   testBuffer,
                                   sizeof( testBuffer ),
                                   dnsResolve,
@@ -444,6 +455,7 @@ void test_Init_InvalidParams( void )
                        Sntp_Init( &context,
                                   testServers,
                                   sizeof( testServers ) / sizeof( SntpServerInfo_t ),
+                                  TEST_RESPONSE_TIMEOUT,
                                   testBuffer,
                                   sizeof( testBuffer ),
                                   dnsResolve,
@@ -465,6 +477,7 @@ void test_Init_Nominal( void )
                            Sntp_Init( &context,                                                                \
                                       testServers,                                                             \
                                       sizeof( testServers ) / sizeof( SntpServerInfo_t ),                      \
+                                      TEST_RESPONSE_TIMEOUT,                                                   \
                                       testBuffer,                                                              \
                                       sizeof( testBuffer ),                                                    \
                                       dnsResolve,                                                              \

--- a/test/unit-test/core_sntp_config.h
+++ b/test/unit-test/core_sntp_config.h
@@ -37,9 +37,6 @@
 #define PrintfInfo( ... )     printf( "Info: " __VA_ARGS__ ); printf( "\n" )
 #define PrintfDebug( ... )    printf( "Debug: " __VA_ARGS__ ); printf( "\n" )
 
-/* Build with Debug level. */
-/*#define LOGGING_LEVEL_DEBUG    1 */
-
 #ifdef LOGGING_LEVEL_ERROR
     #define LogError( message )    PrintfError message
 #elif defined( LOGGING_LEVEL_WARNING )

--- a/test/unit-test/core_sntp_config.h
+++ b/test/unit-test/core_sntp_config.h
@@ -32,10 +32,10 @@
 
 /************* Define Logging Macros using printf function ***********/
 
-#define PrintfError( ... )    printf( "Error: "__VA_ARGS__ );  printf( "\n" )
-#define PrintfWarn( ... )     printf( "Warn: "__VA_ARGS__ );  printf( "\n" )
-#define PrintfInfo( ... )     printf( "Info: " __VA_ARGS__ ); printf( "\n" )
-#define PrintfDebug( ... )    printf( "Debug: " __VA_ARGS__ ); printf( "\n" )
+#define PrintfError( ... )         printf( "Error: "__VA_ARGS__ );  printf( "\n" )
+#define PrintfWarn( ... )          printf( "Warn: "__VA_ARGS__ );  printf( "\n" )
+#define PrintfInfo( ... )          printf( "Info: " __VA_ARGS__ ); printf( "\n" )
+#define PrintfDebug( ... )         printf( "Debug: " __VA_ARGS__ ); printf( "\n" )
 
 #ifdef LOGGING_LEVEL_ERROR
     #define LogError( message )    PrintfError message


### PR DESCRIPTION
Add a `Sntp_ReceiveTimeResponse` API to allow application to obtain the response for a time request that was made to a server (with `Sntp_SendTimeRequest` API). 

The API looks at 3 different timeouts in its operations: 
1. **Server Response timeout** - This PR adds a **responseTimeoutMs** state to the `SntpContext_t` to allow the application to specify timeouts for server responses (to time requests). The timeout period for a server starts after the `Sntp_SendTimeRequest` API is called to send a request to the server. The `Sntp_ReceiveTimeResponse` API keeps a track of whether server response has timed out whenever it is called, and returns a `SntpServerResponseTimeout` error code (even if the **blockTimeMs** value still allows more time window for waiting on server response).  

2. **Block Time** - The API takes a **blockTimeMs** parameter which determines the maximum amount of time the function will block waiting for the server response UNLESS either the server response is received OR the server response has **timed out** OR there is a network read error encountered (like hitting a read retry timeout)  

3. **Read Retry Timeout** - This PR adds an `SNTP_RECV_POLLING_TIMEOUT_MS` configuration macro that represents the maximum time window of retrying zero data reads. This window is only initiated after  some partial data is initially read from the network. The rationale is that when some initial data is available from the network, then it is likely that the remaining SNTP response packet will be available and thus, the **read retry timeout** window starts. The `Sntp_ReceiveTimeResponse` API uses this configuration value to retry partial data reads on the network. 