### PR TITLE
Refactor calculateClockOffset to fix overflow issues


### DIFF
--- a/lexicon.txt
+++ b/lexicon.txt
@@ -106,6 +106,7 @@ pnetworkcontext
 pnetworkcontext
 pnetworkintf
 poldertime
+positivediff
 posix
 ppacket
 pparsedresponse

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -42,7 +42,7 @@ expectedinterval
 expectedtxtime
 faqs
 feb
-firstorderdiff 
+firstorderdiff
 fracs
 fracsinnetorder
 fracsinnetorder
@@ -153,7 +153,8 @@ servernamelen
 serverport
 servertime
 setsystemtimefunc
-signedfirstorderdiffrecv 
+signedfirstorderdiffrecv
+signedfirstorderdiffsend
 sizeof
 sntp
 sntpbuffertoosmall

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -16,6 +16,7 @@ bytestorecv
 bytestorecv
 bytestosend
 bytestosend
+clienttime
 clienttxtime
 clockfreqtolerance
 clockoffsetsec
@@ -41,6 +42,7 @@ expectedinterval
 expectedtxtime
 faqs
 feb
+firstorderdiff 
 fracs
 fracsinnetorder
 fracsinnetorder
@@ -149,7 +151,9 @@ serializerequest
 serveraddr
 servernamelen
 serverport
+servertime
 setsystemtimefunc
+signedfirstorderdiffrecv 
 sizeof
 sntp
 sntpbuffertoosmall
@@ -176,6 +180,7 @@ startingpos
 struct
 sublicense
 testbuffer
+testclockoffsetcalculation
 timebeforeloop
 timeserver
 transmittime

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -1,3 +1,4 @@
+actualabsdiff
 aes
 alarmservernotsynchronized
 api
@@ -37,6 +38,7 @@ deserialize
 deserializer
 deserializeresponse
 desiredaccuracy
+diff
 dns
 doxygen
 endian
@@ -163,6 +165,7 @@ servernamelen
 serverport
 serverresponsetimeoutms
 servertime
+servertxtime
 setsystemtimefunc
 signedfirstorderdiffrecv
 signedfirstorderdiffsend

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -86,6 +86,7 @@ numofservers
 oldertime
 org
 origintime
+overflown
 packetsize
 param
 pauthcodesize

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -16,6 +16,7 @@ bytestorecv
 bytestorecv
 bytestosend
 bytestosend
+cbmc
 clienttime
 clienttxtime
 clockfreqtolerance
@@ -60,6 +61,7 @@ ifndef
 inc
 ingroup
 inlooptime
+int
 iot
 ip
 iso

--- a/source/core_sntp_serializer.c
+++ b/source/core_sntp_serializer.c
@@ -335,16 +335,16 @@ static SntpStatus_t calculateClockOffset( const SntpTimestamp_t * pClientTxTime,
         /* To avoid overflow issues in assigning the unsigned values of first order differences
          * to signed integers, we will inverse the values if they represent a large value that cannot be
          * represented in a signed integer. */
-        if( ( firstOrderDiffSend & UINT32_MOST_SIGNIFICANT_BIT_BIT_MASK ) 
-        == UINT32_MOST_SIGNIFICANT_BIT_BIT_MASK )
+        if( ( firstOrderDiffSend & UINT32_MOST_SIGNIFICANT_BIT_BIT_MASK )
+            == UINT32_MOST_SIGNIFICANT_BIT_BIT_MASK )
 
         {
             firstOrderDiffSend = 0U - firstOrderDiffSend;
             sendPolarity = !sendPolarity;
         }
 
-        if( ( firstOrderDiffRecv & UINT32_MOST_SIGNIFICANT_BIT_BIT_MASK ) 
-        == UINT32_MOST_SIGNIFICANT_BIT_BIT_MASK )
+        if( ( firstOrderDiffRecv & UINT32_MOST_SIGNIFICANT_BIT_BIT_MASK )
+            == UINT32_MOST_SIGNIFICANT_BIT_BIT_MASK )
 
         {
             firstOrderDiffRecv = 0U - firstOrderDiffRecv;

--- a/source/core_sntp_serializer.c
+++ b/source/core_sntp_serializer.c
@@ -237,16 +237,15 @@ static int32_t safeSignedSubtraction( uint32_t minuend,
 {
     int32_t calculatedValue = 0;
 
-    /* The correct polarity of subtraction is "minuend - subtrahend",
-    * but to avoid overflow in subtraction of unsigned integers, we perform
-    * subtraction in the polarity that generates a positive value. */
+    /* The correct polarity of subtraction is "minuend - subtrahend"
+     * but to avoid overflow in subtraction of unsigned integers, we perform
+     * subtraction in the polarity that generates a positive value. */
     bool polarity = ( minuend > subtrahend ) ? true : false;
     uint32_t positiveDiff = ( polarity == true ) ? minuend - subtrahend :
                             subtrahend - minuend;
 
     /* Check whether the difference value cannot be represented as a signed
-     * integer without some modification. An unsigned integer with the most significant
-     * bit set cannot be safely assigned to a signed integer.*/
+     * integer without some modification.*/
     if( positiveDiff > INT32_MAX )
     {
         /* Perform 2's complement inversion of the value to convert it to a value less

--- a/source/core_sntp_serializer.c
+++ b/source/core_sntp_serializer.c
@@ -229,16 +229,27 @@ static bool isEligibleForClockOffsetCalculation( uint32_t firstOrderDiff )
      *                                                  = 0x0000000B
      *                                                  = 11 seconds
      */
-    bool sameNtpEraCheck = ( ( firstOrderDiff & CLOCK_OFFSET_FIRST_ORDER_DIFF_OVERFLOW_BITS_MASK ) == 0U ) ?
-                           true : false;
+    bool sameNtpEraCheck = false;
+    bool diffNtpEraCheck = false;
 
-    /* Note: The (UINT32_MAX  - firstOrderDiff + 1U) expression represents
-     * 2's complement or negation of value.
-     * This is done to be compliant with both CBMC and MISRA Rule 10.1.
-     * CBMC flags overflow for (unsigned int = 0U - positive value) whereas
-     * MISRA rule forbids use of unary minus operator on unsigned integers. */
-    bool diffNtpEraCheck = ( ( ( UINT32_MAX - firstOrderDiff + 1U )
-                               & CLOCK_OFFSET_FIRST_ORDER_DIFF_OVERFLOW_BITS_MASK ) == 0U ) ? true : false;
+    /* Check if the server and client times are within 34 years of each other, if we assume that they are
+     * in the same NTP era. */
+    sameNtpEraCheck = ( ( firstOrderDiff & CLOCK_OFFSET_FIRST_ORDER_DIFF_OVERFLOW_BITS_MASK ) == 0U ) ?
+                      true : false;
+
+    /* If the same era check does not satisfy the 34 years condition, check
+     * whether the condition is satisfied when assuming the that the systems are in
+     * different NTP eras. */
+    if( sameNtpEraCheck == false )
+    {
+        /* Note: The (UINT32_MAX  - firstOrderDiff + 1U) expression represents
+         * 2's complement or negation of value.
+         * This is done to be compliant with both CBMC and MISRA Rule 10.1.
+         * CBMC flags overflow for (unsigned int = 0U - positive value) whereas
+         * MISRA rule forbids use of unary minus operator on unsigned integers. */
+        diffNtpEraCheck = ( ( ( UINT32_MAX - firstOrderDiff + 1U )
+                              & CLOCK_OFFSET_FIRST_ORDER_DIFF_OVERFLOW_BITS_MASK ) == 0U ) ? true : false;
+    }
 
     return( sameNtpEraCheck || diffNtpEraCheck );
 }

--- a/source/core_sntp_serializer.c
+++ b/source/core_sntp_serializer.c
@@ -232,8 +232,8 @@ static bool isEligibleForClockOffsetCalculation( uint32_t firstOrderDiff )
  *
  * @return The calculated signed subtraction value between the unsigned integers.
  */
-static int32_t safeSubtraction( uint32_t minuend,
-                                uint32_t subtrahend )
+static int32_t safeSignedSubtraction( uint32_t minuend,
+                                      uint32_t subtrahend )
 {
     int32_t calculatedValue = 0;
 
@@ -378,8 +378,8 @@ static SntpStatus_t calculateClockOffset( const SntpTimestamp_t * pClientTxTime,
 
         /* Calculate the first order differences in the correct subtraction direction as
          * "Server Time - Client Time" on both SNTP request and SNTP response network paths. */
-        signedFirstOrderDiffSend = safeSubtraction( pServerRxTime->seconds, pClientTxTime->seconds );
-        signedFirstOrderDiffRecv = safeSubtraction( pServerTxTime->seconds, pClientRxTime->seconds );
+        signedFirstOrderDiffSend = safeSignedSubtraction( pServerRxTime->seconds, pClientTxTime->seconds );
+        signedFirstOrderDiffRecv = safeSignedSubtraction( pServerTxTime->seconds, pClientRxTime->seconds );
 
         /* We are now sure that each of the first order differences represents the values in
          * the correct direction of polarities, i.e.

--- a/source/core_sntp_serializer.c
+++ b/source/core_sntp_serializer.c
@@ -220,8 +220,12 @@ static uint32_t readWordFromNetworkByteOrderMemory( const uint32_t * ptr )
  */
 static bool isEligibleForClockOffsetCalculation( uint32_t firstOrderDiff )
 {
+    /* Note: The (1U + ~firstOrderDiff) expression represents 2's complement or negation of value.
+     * This is done to be compliant with both CBMC and MISRA Rule 10.1.
+     * CBMC flags overflow for (unsigned int = 0U - positive value) whereas
+     * MISRA rule forbids use of unary minus operator on unsigned integers. */
     return( ( ( firstOrderDiff & CLOCK_OFFSET_FIRST_ORDER_DIFF_OVERFLOW_BITS_MASK ) == 0U ) ||
-            ( ( ( 0U - firstOrderDiff ) & CLOCK_OFFSET_FIRST_ORDER_DIFF_OVERFLOW_BITS_MASK ) == 0U ) );
+            ( ( ( 1U + ~firstOrderDiff ) & CLOCK_OFFSET_FIRST_ORDER_DIFF_OVERFLOW_BITS_MASK ) == 0U ) );
 }
 
 /**
@@ -341,7 +345,11 @@ static SntpStatus_t calculateClockOffset( const SntpTimestamp_t * pClientTxTime,
             == UINT32_MOST_SIGNIFICANT_BIT_BIT_MASK )
 
         {
-            firstOrderDiffSend = 0U - firstOrderDiffSend;
+            /* Negate the unsigned integer by performing 2's complement operation.
+             * Note: This is done to be compliant with both CBMC and MISRA Rule 10.1.
+             * CBMC flags overflow for (unsigned int = 0U - positive value) whereas
+             * MISRA rule forbids use of unary minus operator on unsigned integers. */
+            firstOrderDiffSend = 1U + ~firstOrderDiffSend;
             sendPolarity = !sendPolarity;
         }
 
@@ -349,7 +357,11 @@ static SntpStatus_t calculateClockOffset( const SntpTimestamp_t * pClientTxTime,
             == UINT32_MOST_SIGNIFICANT_BIT_BIT_MASK )
 
         {
-            firstOrderDiffRecv = 0U - firstOrderDiffRecv;
+            /* Negate the unsigned integer by performing 2's complement operation.
+             * Note: This is done to be compliant with both CBMC and MISRA Rule 10.1.
+             * CBMC flags overflow for (unsigned int = 0U - positive value) whereas
+             * MISRA rule forbids use of unary minus operator on unsigned integers. */
+            firstOrderDiffRecv = 1U + ~firstOrderDiffRecv;
             recvPolarity = !recvPolarity;
         }
 

--- a/source/core_sntp_serializer.c
+++ b/source/core_sntp_serializer.c
@@ -218,7 +218,7 @@ static uint32_t readWordFromNetworkByteOrderMemory( const uint32_t * ptr )
  * to support the edge case when the two timestamps are in different SNTP eras (for
  * example, server time is in 2037 and client time is in 2035 ).
  */
-static bool isEligibileForClockOffsetCalculation( uint32_t firstOrderDiff )
+static bool isEligibleForClockOffsetCalculation( uint32_t firstOrderDiff )
 {
     return( ( ( firstOrderDiff & CLOCK_OFFSET_FIRST_ORDER_DIFF_OVERFLOW_BITS_MASK ) == 0U ) ||
             ( ( ( 0U - firstOrderDiff ) & CLOCK_OFFSET_FIRST_ORDER_DIFF_OVERFLOW_BITS_MASK ) == 0U ) );
@@ -324,8 +324,8 @@ static SntpStatus_t calculateClockOffset( const SntpTimestamp_t * pClientTxTime,
     /* Determine from the first order differences if the system time is within
      * 34 years of server time to be able to calculate clock offset.
      */
-    if( isEligibileForClockOffsetCalculation( firstOrderDiffSend ) &&
-        isEligibileForClockOffsetCalculation( firstOrderDiffRecv ) )
+    if( isEligibleForClockOffsetCalculation( firstOrderDiffSend ) &&
+        isEligibleForClockOffsetCalculation( firstOrderDiffRecv ) )
     {
         /* Now that we have validated that system and server times are within 34 years
          * of each other, we will prepare for the clock-offset calculation. To calculate

--- a/source/core_sntp_serializer.c
+++ b/source/core_sntp_serializer.c
@@ -220,12 +220,12 @@ static uint32_t readWordFromNetworkByteOrderMemory( const uint32_t * ptr )
  */
 static bool isEligibleForClockOffsetCalculation( uint32_t firstOrderDiff )
 {
-    /* Note: The (1U + ~firstOrderDiff) expression represents 2's complement or negation of value.
+    /* Note: The (~firstOrderDiff + 1U) expression represents 2's complement or negation of value.
      * This is done to be compliant with both CBMC and MISRA Rule 10.1.
      * CBMC flags overflow for (unsigned int = 0U - positive value) whereas
      * MISRA rule forbids use of unary minus operator on unsigned integers. */
     return( ( ( firstOrderDiff & CLOCK_OFFSET_FIRST_ORDER_DIFF_OVERFLOW_BITS_MASK ) == 0U ) ||
-            ( ( ( 1U + ~firstOrderDiff ) & CLOCK_OFFSET_FIRST_ORDER_DIFF_OVERFLOW_BITS_MASK ) == 0U ) );
+            ( ( ( ~firstOrderDiff + 1U ) & CLOCK_OFFSET_FIRST_ORDER_DIFF_OVERFLOW_BITS_MASK ) == 0U ) );
 }
 
 /**
@@ -307,12 +307,12 @@ static SntpStatus_t calculateClockOffset( const SntpTimestamp_t * pClientTxTime,
     assert( pClockOffset != NULL );
 
     /* On-wire protocol formula's polarity for first order difference in the send network
-     * path is T2 (Server Rx) - T1 (Client TX) .*/
-    recvPolarity = ( pServerTxTime->seconds >= pClientRxTime->seconds ) ? true : false;
+     * path is T2 (Server Rx) - T1 (Client Tx) .*/
+    sendPolarity = ( pServerRxTime->seconds >= pClientTxTime->seconds ) ? true : false;
 
     /* On-wire protocol formula's polarity for first order difference in the receive network
-     * path is T3 (Server TX) - T4 (Client RX) .*/
-    sendPolarity = ( pServerRxTime->seconds >= pClientTxTime->seconds ) ? true : false;
+     * path is T3 (Server Tx) - T4 (Client Rx) .*/
+    recvPolarity = ( pServerTxTime->seconds >= pClientRxTime->seconds ) ? true : false;
 
     /* Calculate first order difference values between the server and system timestamps
      * to determine whether they are within 34 years of each other. */
@@ -349,7 +349,7 @@ static SntpStatus_t calculateClockOffset( const SntpTimestamp_t * pClientTxTime,
              * Note: This is done to be compliant with both CBMC and MISRA Rule 10.1.
              * CBMC flags overflow for (unsigned int = 0U - positive value) whereas
              * MISRA rule forbids use of unary minus operator on unsigned integers. */
-            firstOrderDiffSend = 1U + ~firstOrderDiffSend;
+            firstOrderDiffSend = ~firstOrderDiffSend + 1U;
             sendPolarity = !sendPolarity;
         }
 
@@ -361,7 +361,7 @@ static SntpStatus_t calculateClockOffset( const SntpTimestamp_t * pClientTxTime,
              * Note: This is done to be compliant with both CBMC and MISRA Rule 10.1.
              * CBMC flags overflow for (unsigned int = 0U - positive value) whereas
              * MISRA rule forbids use of unary minus operator on unsigned integers. */
-            firstOrderDiffRecv = 1U + ~firstOrderDiffRecv;
+            firstOrderDiffRecv = ~firstOrderDiffRecv + 1U;
             recvPolarity = !recvPolarity;
         }
 

--- a/test/unit-test/core_sntp_serializer_utest.c
+++ b/test/unit-test/core_sntp_serializer_utest.c
@@ -137,6 +137,9 @@ static void testClockOffsetCalculation( SntpTimestamp_t * clientTxTime,
                                         int32_t expectedClockOffset )
 {
     /* Update the response packet with the server time. */
+    addTimestampToResponseBuffer( clientTxTime,
+                                  testBuffer,
+                                  SNTP_PACKET_ORIGIN_TIME_FIRST_BYTE_POS );
     addTimestampToResponseBuffer( serverRxTime,
                                   testBuffer,
                                   SNTP_PACKET_RX_TIMESTAMP_FIRST_BYTE_POS );
@@ -498,6 +501,8 @@ void test_DeserializeResponse_AcceptedResponse_Nominal_Case( void )
     /* Use the the same values for Rx and Tx times for server and client in the first couple
      * of tests for simplicity. */
 
+    /* ==================Test when client and server are in same NTP era.================ */
+
     /* Test when the client is 20 years ahead of server time to generate a negative offset
      * result.*/
     SntpTimestamp_t serverTxTime =
@@ -513,8 +518,29 @@ void test_DeserializeResponse_AcceptedResponse_Nominal_Case( void )
 
     /* Now test for the client being 20 years behind server time to generate a positive
      * offset result.*/
-    serverTxTime.seconds = clientTxTime.seconds + YEARS_20_IN_SECONDS;
+    serverTxTime.seconds = UINT32_MAX;
+    clientTxTime.seconds = UINT32_MAX - YEARS_20_IN_SECONDS;
     expectedOffset = YEARS_20_IN_SECONDS;
+
+    testClockOffsetCalculation( &clientTxTime, &serverTxTime,
+                                &serverTxTime, &clientTxTime,
+                                SntpSuccess, expectedOffset );
+
+    /* ==================Test when client and server are in different NTP eras.================ */
+
+    /* Test when the server is ahead of client to generate a positive clock offset result.*/
+    clientTxTime.seconds = UINT32_MAX;                       /* Client is in NTP era 0. */
+    serverTxTime.seconds = UINT32_MAX + YEARS_20_IN_SECONDS; /* Server is in NTP era 1. */
+    expectedOffset = YEARS_20_IN_SECONDS;
+
+    testClockOffsetCalculation( &clientTxTime, &serverTxTime,
+                                &serverTxTime, &clientTxTime,
+                                SntpSuccess, expectedOffset );
+
+    /* Test when the client is ahead of server to generate a negative clock offset result.*/
+    clientTxTime.seconds = UINT32_MAX + YEARS_20_IN_SECONDS; /* Client is in NTP era 1. */
+    serverTxTime.seconds = UINT32_MAX;                       /* Server is in NTP era 0. */
+    expectedOffset = -YEARS_20_IN_SECONDS;
 
     testClockOffsetCalculation( &clientTxTime, &serverTxTime,
                                 &serverTxTime, &clientTxTime,
@@ -524,6 +550,7 @@ void test_DeserializeResponse_AcceptedResponse_Nominal_Case( void )
      * that are used in the clock-offset calculation.
      * The test case uses 2 seconds as network delay on both Client -> Server and Server -> Client path
      * and 2 seconds for server processing time between receiving SNTP request and sending SNTP response */
+    clientTxTime.seconds = UINT32_MAX;
     SntpTimestamp_t serverRxTime =
     {
         clientTxTime.seconds + YEARS_20_IN_SECONDS + 2,

--- a/test/unit-test/core_sntp_serializer_utest.c
+++ b/test/unit-test/core_sntp_serializer_utest.c
@@ -441,7 +441,7 @@ void test_DeserializeResponse_KoD_packets( void )
  * SNTP server response, and determine that the clock offset cannot be calculated
  * when the client clock is beyond 34 years from server.
  */
-void test_DeserializeResponse_AcceptedResponse_Overflow_Case( void )
+void test_DeserializeResponse_AcceptedResponse_Overflow_Cases( void )
 {
     SntpTimestamp_t clientTime = TEST_TIMESTAMP;
 
@@ -463,6 +463,22 @@ void test_DeserializeResponse_AcceptedResponse_Overflow_Case( void )
     serverTime.seconds = clientTime.seconds + YEARS_40_IN_SECONDS;
     testClockOffsetCalculation( &clientTime, &serverTime,
                                 &serverTime, &clientTime,
+                                SntpClockOffsetOverflow,
+                                SNTP_CLOCK_OFFSET_OVERFLOW );
+
+    /* Now test the contrived case when only the send network path
+     * represents timestamps that overflow but the receive network path
+     * has timestamps that do not overflow. */
+    testClockOffsetCalculation( &clientTime, &serverTime, /* Send Path times are 40 years apart */
+                                &serverTime, &serverTime, /* Receive path times are the same. */
+                                SntpClockOffsetOverflow,
+                                SNTP_CLOCK_OFFSET_OVERFLOW );
+
+    /* Now test the contrived case when only the receive network path
+     * represents timestamps that overflow but the send network path
+     * has timestamps that do not overflow. */
+    testClockOffsetCalculation( &clientTime, &clientTime, /* Send Path times are the same, i.e. don't overflow */
+                                &serverTime, &clientTime, /* Receive path times are 40 years apart. */
                                 SntpClockOffsetOverflow,
                                 SNTP_CLOCK_OFFSET_OVERFLOW );
 }


### PR DESCRIPTION
CBMC proof run for `Sntp_DeserializeResponse` PR #15 flags overflow issue in the `calculateClockOffset` function when assignining negative value to an unsigned integer. This PR refactors the implementation to avoid overflow flagging by: 
* Storing only positive subtraction values in unsigned integers 
* Assigning a large unsigned integer (i.e. >= 0x80000000) to signed integer by first using its negative value and then inversing the negation _after_ the assignment to obtain the correct value. 

This PR also adds resiliency to the clock-offset calculation by adding check against overflow (i.e. when server and client times are more than 34 years apart) on the Client -> Server SNTP request send network path. 