### PR TITLE
Fix bugs causing integer overflow issue in clock-offset calculation

### DIFF
--- a/source/core_sntp_serializer.c
+++ b/source/core_sntp_serializer.c
@@ -247,6 +247,10 @@ static int64_t safeTimeDifference( uint32_t serverTimeSec,
      * are in the same NTP era. */
     int64_t diffWithNoEraAdjustment = serverTime - clientTime;
 
+    /* Store the absolute value of the time difference which will be used for comparison with
+     * different cases of relative NTP era configuration of client and server times. */
+    int64_t absSameEraDiff = absoluteOf( diffWithNoEraAdjustment );
+
     /* If the absolute difference value is 2^31 seconds, it means that the server and client times are
      * away by exactly half the range of SNTP timestamp "second" values representable in unsigned 32 bits.
      * In this case, the NTP era presence of the server and client systems cannot be determined just
@@ -257,7 +261,7 @@ static int64_t safeTimeDifference( uint32_t serverTimeSec,
      *, we will return the maximum value representable by signed 2^31, i.e. 2147483647, resulting in
      * an inaccuracy of 1 second in the clock-offset value.
      */
-    if( absoluteOf( diffWithNoEraAdjustment ) == CLOCK_OFFSET_MAX_TIME_DIFFERENCE )
+    if( absSameEraDiff == CLOCK_OFFSET_MAX_TIME_DIFFERENCE )
     {
         /* It does not matter whether server and client are in the same era for this
          * special case as the difference value for both same and adjacent eras will yield
@@ -282,7 +286,6 @@ static int64_t safeTimeDifference( uint32_t serverTimeSec,
 
         /* Store the absolute value equivalents of all the time difference configurations
          * for easier comparison to smallest value from them. */
-        int64_t absSameEraDiff = absoluteOf( diffWithNoEraAdjustment );
         int64_t absServerEraAheadDiff = absoluteOf( diffWithServerEraAdjustment );
         int64_t absClientEraAheadDiff = absoluteOf( diffWithClientEraAdjustment );
 

--- a/test/cbmc/proofs/Sntp_DeserializeResponse/Makefile
+++ b/test/cbmc/proofs/Sntp_DeserializeResponse/Makefile
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = Sntp_DeserializeResponse_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = Sntp_DeserializeResponse
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/source/core_sntp_serializer.c
+
+include ../Makefile.common

--- a/test/cbmc/proofs/Sntp_DeserializeResponse/README.md
+++ b/test/cbmc/proofs/Sntp_DeserializeResponse/README.md
@@ -1,0 +1,20 @@
+Sntp_DeserializeResponse proof
+==============
+
+This directory contains a memory safety proof for Sntp_DeserializeResponse.
+
+To run the proof.
+-------------
+
+* Add `cbmc`, `goto-cc`, `goto-instrument`, `goto-analyzer`, and `cbmc-viewer`
+  to your path.
+* Run `make`.
+* Open html/index.html in a web browser.
+
+To use [`arpa`](https://github.com/awslabs/aws-proof-build-assistant) to simplify writing Makefiles.
+-------------
+
+* Run `make arpa` to generate a Makefile.arpa that contains relevant build information for the proof.
+* Use Makefile.arpa as the starting point for your proof Makefile by:
+  1. Modifying Makefile.arpa (if required).
+  2. Including Makefile.arpa into the existing proof Makefile (add `sinclude Makefile.arpa` at the bottom of the Makefile, right before `include ../Makefile.common`).

--- a/test/cbmc/proofs/Sntp_DeserializeResponse/Sntp_DeserializeResponse_harness.c
+++ b/test/cbmc/proofs/Sntp_DeserializeResponse/Sntp_DeserializeResponse_harness.c
@@ -1,0 +1,52 @@
+/*
+  * coreSNTP v1.0.0
+  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy of
+  * this software and associated documentation files (the "Software"), to deal in
+  * the Software without restriction, including without limitation the rights to
+  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+  * the Software, and to permit persons to whom the Software is furnished to do so,
+  * subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  */
+
+ /**
+  * @file Sntp_DeserializeResponse_harness.c
+  * @brief Implements the proof harness for Sntp_DeserializeResponse function.
+  */
+
+ #include <stdint.h>
+ #include "core_sntp_serializer.h"
+
+ void harness()
+ {
+     SntpTimestamp_t * pRequestTime;
+     SntpTimestamp_t * pResponseRxTime;
+     void * pResponseBuffer;
+     size_t bufferSize;
+     SntpResponseData_t * pParsedResponse;
+     SntpStatus_t sntpStatus;
+
+     __CPROVER_assume( bufferSize < CBMC_MAX_OBJECT_SIZE );
+
+     pRequestTime = malloc( sizeof( SntpTimestamp_t ) );
+     pResponseRxTime = malloc( sizeof( SntpTimestamp_t ) );
+     pResponseBuffer = malloc( bufferSize );
+     pParsedResponse = malloc( sizeof( SntpResponseData_t ) );
+
+     sntpStatus = Sntp_DeserializeResponse( pRequestTime, pResponseRxTime, pResponseBuffer, bufferSize, pParsedResponse );
+
+     __CPROVER_assert( ( sntpStatus == SntpErrorBadParameter ) || ( sntpStatus == SntpErrorBufferTooSmall ) ||
+                       ( sntpStatus == SntpInvalidResponse ) || ( sntpStatus == SntpSuccess ) || ( sntpStatus == SntpRejectedResponseChangeServer ) ||
+                       ( sntpStatus == SntpRejectedResponseRetryWithBackoff ) || ( sntpStatus == SntpRejectedResponseOtherCode ) , "This is a valid sntp return status" );
+ }

--- a/test/cbmc/proofs/Sntp_DeserializeResponse/Sntp_DeserializeResponse_harness.c
+++ b/test/cbmc/proofs/Sntp_DeserializeResponse/Sntp_DeserializeResponse_harness.c
@@ -1,52 +1,52 @@
 /*
-  * coreSNTP v1.0.0
-  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-  *
-  * Permission is hereby granted, free of charge, to any person obtaining a copy of
-  * this software and associated documentation files (the "Software"), to deal in
-  * the Software without restriction, including without limitation the rights to
-  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-  * the Software, and to permit persons to whom the Software is furnished to do so,
-  * subject to the following conditions:
-  *
-  * The above copyright notice and this permission notice shall be included in all
-  * copies or substantial portions of the Software.
-  *
-  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-  */
+ * coreSNTP v1.0.0
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 
- /**
-  * @file Sntp_DeserializeResponse_harness.c
-  * @brief Implements the proof harness for Sntp_DeserializeResponse function.
-  */
+/**
+ * @file Sntp_DeserializeResponse_harness.c
+ * @brief Implements the proof harness for Sntp_DeserializeResponse function.
+ */
 
- #include <stdint.h>
- #include "core_sntp_serializer.h"
+#include <stdint.h>
+#include "core_sntp_serializer.h"
 
- void harness()
- {
-     SntpTimestamp_t * pRequestTime;
-     SntpTimestamp_t * pResponseRxTime;
-     void * pResponseBuffer;
-     size_t bufferSize;
-     SntpResponseData_t * pParsedResponse;
-     SntpStatus_t sntpStatus;
+void harness()
+{
+    SntpTimestamp_t * pRequestTime;
+    SntpTimestamp_t * pResponseRxTime;
+    void * pResponseBuffer;
+    size_t bufferSize;
+    SntpResponseData_t * pParsedResponse;
+    SntpStatus_t sntpStatus;
 
-     __CPROVER_assume( bufferSize < CBMC_MAX_OBJECT_SIZE );
+    __CPROVER_assume( bufferSize < CBMC_MAX_OBJECT_SIZE );
 
-     pRequestTime = malloc( sizeof( SntpTimestamp_t ) );
-     pResponseRxTime = malloc( sizeof( SntpTimestamp_t ) );
-     pResponseBuffer = malloc( bufferSize );
-     pParsedResponse = malloc( sizeof( SntpResponseData_t ) );
+    pRequestTime = malloc( sizeof( SntpTimestamp_t ) );
+    pResponseRxTime = malloc( sizeof( SntpTimestamp_t ) );
+    pResponseBuffer = malloc( bufferSize );
+    pParsedResponse = malloc( sizeof( SntpResponseData_t ) );
 
-     sntpStatus = Sntp_DeserializeResponse( pRequestTime, pResponseRxTime, pResponseBuffer, bufferSize, pParsedResponse );
+    sntpStatus = Sntp_DeserializeResponse( pRequestTime, pResponseRxTime, pResponseBuffer, bufferSize, pParsedResponse );
 
-     __CPROVER_assert( ( sntpStatus == SntpErrorBadParameter ) || ( sntpStatus == SntpErrorBufferTooSmall ) ||
-                       ( sntpStatus == SntpInvalidResponse ) || ( sntpStatus == SntpSuccess ) || ( sntpStatus == SntpRejectedResponseChangeServer ) ||
-                       ( sntpStatus == SntpRejectedResponseRetryWithBackoff ) || ( sntpStatus == SntpRejectedResponseOtherCode ) , "This is a valid sntp return status" );
- }
+    __CPROVER_assert( ( sntpStatus == SntpErrorBadParameter ) || ( sntpStatus == SntpErrorBufferTooSmall ) ||
+                      ( sntpStatus == SntpInvalidResponse ) || ( sntpStatus == SntpSuccess ) || ( sntpStatus == SntpRejectedResponseChangeServer ) ||
+                      ( sntpStatus == SntpRejectedResponseRetryWithBackoff ) || ( sntpStatus == SntpRejectedResponseOtherCode ), "This is a valid sntp return status" );
+}

--- a/test/cbmc/proofs/Sntp_DeserializeResponse/cbmc-proof.txt
+++ b/test/cbmc/proofs/Sntp_DeserializeResponse/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/test/cbmc/proofs/Sntp_DeserializeResponse/cbmc-viewer.json
+++ b/test/cbmc/proofs/Sntp_DeserializeResponse/cbmc-viewer.json
@@ -1,0 +1,7 @@
+{ "expected-missing-functions":
+  [
+
+  ],
+  "proof-name": "Sntp_DeserializeResponse",
+  "proof-root": "test/cbmc/proofs"
+}

--- a/test/unit-test/core_sntp_serializer_utest.c
+++ b/test/unit-test/core_sntp_serializer_utest.c
@@ -474,16 +474,22 @@ void test_DeserializeResponse_AcceptedResponse_ClockOffset_Edge_Cases( void )
      * is ahead of the client in this special case, and thus return the maximum
      * signed 32 bit integer as the clock-offset.
      */
-    serverTime.seconds = clientTime.seconds - INT32_MAX - 1;
-    testClockOffsetCalculation( &clientTime, &serverTime,
-                                &serverTime, &clientTime,
-                                SntpSuccess,
-                                INT32_MAX );
+    /* Case when "Server Time - Client Time" results in negative value. */
     serverTime.seconds = clientTime.seconds + INT32_MAX + 1;
     testClockOffsetCalculation( &clientTime, &serverTime,
                                 &serverTime, &clientTime,
                                 SntpSuccess,
                                 INT32_MAX );
+    /* Test when "Server Time - Client Time" results in positive value. */
+    serverTime.seconds = UINT32_MAX;
+    clientTime.seconds = serverTime.seconds - INT32_MAX - 1;
+    testClockOffsetCalculation( &clientTime, &serverTime,
+                                &serverTime, &clientTime,
+                                SntpSuccess,
+                                INT32_MAX );
+
+    /* Reset client time to UINT32_MAX */
+    clientTime.seconds = UINT32_MAX;
 
     /* Now test cases when the server and client times are exactly
      * INT32_MAX seconds apart. */


### PR DESCRIPTION
Fix the following causes of **integer overflow** issue in the clock-offset calculation logic refactored in PR #22:
1. The edge-case handling of time difference of 2^31 seconds between the client and server systems was only identifying the case when the "Server Time - Client Time" difference is negative (by explicitly comparing with `INT32_MIN`). This was missing out the case when the first order difference is INT32_MAX + 1 (or  absolute value of INT32_MIN). This PR updates the logic to handle both the scenarios of the first order difference being 2^31 seconds in absolute value.   

2. There is a bug in determining whether the server time is one NTP era ahead of client time which caused incorrect clock-offset value to be chosen amongst the possible combinations of NTP era configuration. This PR fixes the logic for determining that the server time is NTP era ahead of client time.