### PR TITLE
Update Client layer APIs to validate context

### DIFF
--- a/lexicon.txt
+++ b/lexicon.txt
@@ -183,12 +183,14 @@ sntperrorauthfailure
 sntperrorbadparameter
 sntperrorbuffertoosmall
 sntperrorchangeserver
+sntperrorcontextnotinitialized
 sntperrordnsfailure
 sntperrornetworkfailure
 sntperrorresponsetimeout
 sntperrortimenotsupported
 sntpinvalidresponse
 sntpnoresponse
+sntppacketsize
 sntprejectedresponse
 sntprejectedresponsechangeserver
 sntprejectedresponseothercode

--- a/source/core_sntp_client.c
+++ b/source/core_sntp_client.c
@@ -70,7 +70,7 @@ SntpStatus_t Sntp_Init( SntpContext_t * pContext,
         LogError( ( "Invalid parameter: Size of server list cannot be zero" ) );
         status = SntpErrorBadParameter;
     }
-    /* Validate that the members of the UDP transport interface. */
+    /* Validate that the UDP transport interface functions are valid. */
     else if( ( pTransportIntf->recvFrom == NULL ) || ( pTransportIntf->sendTo == NULL ) )
     {
         LogError( ( "Invalid parameter: Function members of UDP transport interface cannot be NULL" ) );
@@ -193,13 +193,13 @@ static bool isContextInitialized( SntpContext_t * pContext )
     {
         isValid = false;
     }
-    /* Validate that the members of the UDP transport interface. */
+    /* Validate that the UDP transport interface functions are valid. */
     else if( ( pContext->networkIntf.recvFrom == NULL ) || ( pContext->networkIntf.sendTo == NULL ) )
     {
         isValid = false;
     }
 
-    /* If an authentication interface is provided, validate that boths its function pointer
+    /* If an authentication interface is provided, validate that both its function pointer
      * members are valid. */
     else if( ( ( pContext->authIntf.generateClientAuth != NULL ) && ( pContext->authIntf.validateServerAuth == NULL ) ) ||
              ( ( pContext->authIntf.generateClientAuth == NULL ) && ( pContext->authIntf.validateServerAuth != NULL ) ) )

--- a/source/include/core_sntp_client.h
+++ b/source/include/core_sntp_client.h
@@ -339,7 +339,7 @@ typedef struct SntpAuthenticationIntf
     SntpGenerateAuthCode_t generateClientAuth;
 
     /**
-     * @brief The user-defined function to authenticating server from its SNTP
+     * @brief The user-defined function for authenticating server from its SNTP
      * response.
      */
     SntpValidateServerAuth_t validateServerAuth;

--- a/source/include/core_sntp_client.h
+++ b/source/include/core_sntp_client.h
@@ -528,6 +528,8 @@ SntpStatus_t Sntp_Init( SntpContext_t * pContext,
  *  - #SntpSuccess if a time request is successfully sent to the currently configured
  * time server in the context.
  *  - #SntpErrorBadParameter if an invalid context is passed to the function.
+ *  - #SntpErrorContextNotInitialized if an uninitialized or invalid context is passed
+ * to the function.
  *  - #SntpErrorChangeServer if there is no server remaining in the list of configured
  * servers that has not rejected a prior time request.
  *  - #SntpErrorDnsFailure if there is failure in the user-defined function for
@@ -580,6 +582,8 @@ SntpStatus_t Sntp_SendTimeRequest( SntpContext_t * pContext,
  *
  * @return This API functions returns one of the following:
  *  - #SntpSuccess if a successful server response is received.
+ *  - #SntpErrorContextNotInitialized if an uninitialized or invalid context is passed
+ * to the function.
  *  - #SntpErrorBadParameter if an invalid context is passed to the function.
  *  - #SntpErrorChangeServer if all servers configured in the context have already
  * rejected time requests in previous attempts, and application SHOULD change server(s)

--- a/source/include/core_sntp_serializer.h
+++ b/source/include/core_sntp_serializer.h
@@ -228,7 +228,13 @@ typedef enum SntpStatus
      * @brief No SNTP packet for server response is received from the network by the
      * @ref Sntp_ReceiveTimeResponse API.
      */
-    SntpNoResponseReceived
+    SntpNoResponseReceived,
+
+    /**
+     * @brief The SNTP context passed to @ref Sntp_SendTimeRequest or @ref Sntp_ReceiveTimeResponse APIs is
+     * is uninitialized.
+     */
+    SntpErrorContextNotInitialized
 } SntpStatus_t;
 
 /**

--- a/test/cbmc/proofs/Sntp_SendTimeRequest/Makefile
+++ b/test/cbmc/proofs/Sntp_SendTimeRequest/Makefile
@@ -22,7 +22,7 @@ INCLUDES +=
 # for this function
 REMOVE_FUNCTION_BODY +=Sntp_SerializeRequest
 UNWINDSET +=__CPROVER_file_local_core_sntp_client_c_sendSntpPacket.0:$(MAX_NETWORK_SEND_TRIES)
-UNWINDSET +=allocateCoreSntpContext.0:$(shell expr $(MAX_NO_OF_SERVERS) + 1 )
+UNWINDSET +=unconstrainedCoreSntpContext.0:$(shell expr $(MAX_NO_OF_SERVERS) + 1 )
 
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/core_sntp_cbmc_state.c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/core_sntp_stubs.c

--- a/test/cbmc/proofs/Sntp_SendTimeRequest/Sntp_SendTimeRequest_harness.c
+++ b/test/cbmc/proofs/Sntp_SendTimeRequest/Sntp_SendTimeRequest_harness.c
@@ -39,6 +39,7 @@ void harness()
     sntpStatus = Sntp_SendTimeRequest( pContext, randomNumber );
 
     __CPROVER_assert( ( sntpStatus == SntpErrorBadParameter || sntpStatus == SntpSuccess ||
+                        sntpStatus == SntpErrorContextNotInitialized ||
                         sntpStatus == SntpErrorBufferTooSmall || sntpStatus == SntpErrorChangeServer ||
                         sntpStatus == SntpErrorDnsFailure || sntpStatus == SntpErrorAuthFailure ||
                         sntpStatus == SntpErrorNetworkFailure ), "The return value is not a valid SNTP Status" );

--- a/test/unit-test/core_sntp_client_utest.c
+++ b/test/unit-test/core_sntp_client_utest.c
@@ -276,6 +276,7 @@ static void testApiForInvalidContextCases( enum SntpClientApiType api )
 
     /* Start with a non-initialized context. */
     SntpContext_t testContext;
+    memset( &testContext, 0, sizeof( SntpContext_t ) );
     SELECT_API_AND_TEST_INVALID_CONTEXT( api, testContext );
 
     /* Now fully initialize context and then test all scenarios with only one member being invalid. */


### PR DESCRIPTION
Update the `Sntp_SendTimeRequest` and `Sntp_ReceiveTimeResponse` APIs to validate the members of the `SntpContext_t` parameter passed toas input to avoid NULL dereferencing issues for pointer members of the context as well as fail immediately for an uininitialized/invalid context instead of attempting to perform the send/recv operation. This PR adds an `SntpErrorContextNotInitialized` error code to handle the case when either an invalid or unininitialized context is passed to the APIs.