### PR TITLE
Update Sntp_ReceiveTimeResponse to rotate server on response timeout

### DIFF
--- a/lexicon.txt
+++ b/lexicon.txt
@@ -36,6 +36,7 @@ currenttimelist
 de
 deamon
 december
+deserialization
 deserialize
 deserializer
 deserializeresponse

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -210,6 +210,7 @@ sublicense
 testbuffer
 testclockoffsetcalculation
 timebeforeloop
+timediffsec
 timeserver
 transmittime
 trng

--- a/source/core_sntp_client.c
+++ b/source/core_sntp_client.c
@@ -173,8 +173,8 @@ static uint32_t calculateElapsedTimeMs( const SntpTimestamp_t * pCurrentTime,
  * - #SntpSuccess if the context is verified to be initialized.
  * - #SntpErrorBadParameter if the context is NULL.
  * - #SntpErrorContextNotInitialized if the context is validated to be initialized.
- * - #SntpErrorChangeServer if no more servers are remaining from the configured list to
- * synchronizing time from.
+ * - #SntpErrorChangeServer if no more servers are remaining from the configured list
+ *   from which to synchronize time.
  */
 static SntpStatus_t validateContext( SntpContext_t * pContext )
 {

--- a/source/include/core_sntp_client.h
+++ b/source/include/core_sntp_client.h
@@ -530,8 +530,6 @@ SntpStatus_t Sntp_Init( SntpContext_t * pContext,
  *  - #SntpErrorBadParameter if an invalid context is passed to the function.
  *  - #SntpErrorContextNotInitialized if an uninitialized or invalid context is passed
  * to the function.
- *  - #SntpErrorChangeServer if there is no server remaining in the list of configured
- * servers that has not rejected a prior time request.
  *  - #SntpErrorDnsFailure if there is failure in the user-defined function for
  * DNS resolution of the time server.
  *  - #SntpErrorNetworkFailure if the SNTP request could not be sent over the network
@@ -570,6 +568,8 @@ SntpStatus_t Sntp_SendTimeRequest( SntpContext_t * pContext,
  *  - The server has responded with a rejection for the time request.
  *                         OR
  *  - The server response wait has timed out.
+ * If all the servers configured in the context have been used, the API will rotate server for
+ * time query back to the first server in the list which will be used in next time request.
  *
  * @param[in] pContext The context representing an SNTPv4 client.
  * @param[in] blockTimeMs The maximum duration of time the function will block on
@@ -585,9 +585,6 @@ SntpStatus_t Sntp_SendTimeRequest( SntpContext_t * pContext,
  *  - #SntpErrorContextNotInitialized if an uninitialized or invalid context is passed
  * to the function.
  *  - #SntpErrorBadParameter if an invalid context is passed to the function.
- *  - #SntpErrorChangeServer if all servers configured in the context have already
- * rejected time requests in previous attempts, and application SHOULD change server(s)
- * for future time requests with the @ref Sntp_Init API.
  *  - #SntpErrorNetworkFailure if there is a failure in the user-defined transport
  *  - #SntpErrorAuthFailure if an internal error occurs in the user-defined
  * authentication interface when validating the server response.

--- a/source/include/core_sntp_serializer.h
+++ b/source/include/core_sntp_serializer.h
@@ -181,16 +181,6 @@ typedef enum SntpStatus
     SntpErrorTimeNotSupported,
 
     /**
-     * @brief No server is available for requesting time as all servers configured in the
-     * SNTP context have rejected a time request in previous attempts. The application
-     * SHOULD change to a new server by re-initializing the context.
-     *
-     * @note This status is returned by either of @ref Sntp_SendTimeRequest OR
-     * @ref Sntp_GetTimeResponse APIs.
-     */
-    SntpErrorChangeServer,
-
-    /**
      * @brief The user-defined DNS resolution interface, @ref SntpResolveDns_t, failed to resolve
      * address for a time server. This status is returned by the @ref Sntp_SendTimeRequest API.
      */

--- a/test/cbmc/proofs/Sntp_ReceiveTimeResponse/Sntp_ReceiveTimeResponse_harness.c
+++ b/test/cbmc/proofs/Sntp_ReceiveTimeResponse/Sntp_ReceiveTimeResponse_harness.c
@@ -54,7 +54,7 @@ void harness()
     sntpStatus = Sntp_ReceiveTimeResponse( pContext, blockTimeMs );
 
     __CPROVER_assert( ( sntpStatus == SntpErrorBadParameter || sntpStatus == SntpSuccess ||
-                        sntpStatus == SntpNoResponseReceived || sntpStatus == SntpErrorChangeServer ||
-                        sntpStatus == SntpRejectedResponse || sntpStatus == SntpErrorResponseTimeout ||
-                        sntpStatus == SntpErrorNetworkFailure ), "The return value is not a valid SNTP Status" );
+                        sntpStatus == SntpNoResponseReceived || sntpStatus == SntpRejectedResponse ||
+                        sntpStatus == SntpErrorResponseTimeout || sntpStatus == SntpErrorNetworkFailure ),
+                      "The return value is not a valid coreSNTP Status" );
 }

--- a/test/cbmc/proofs/Sntp_SendTimeRequest/Sntp_SendTimeRequest_harness.c
+++ b/test/cbmc/proofs/Sntp_SendTimeRequest/Sntp_SendTimeRequest_harness.c
@@ -40,7 +40,7 @@ void harness()
 
     __CPROVER_assert( ( sntpStatus == SntpErrorBadParameter || sntpStatus == SntpSuccess ||
                         sntpStatus == SntpErrorContextNotInitialized ||
-                        sntpStatus == SntpErrorBufferTooSmall || sntpStatus == SntpErrorChangeServer ||
-                        sntpStatus == SntpErrorDnsFailure || sntpStatus == SntpErrorAuthFailure ||
-                        sntpStatus == SntpErrorNetworkFailure ), "The return value is not a valid SNTP Status" );
+                        sntpStatus == SntpErrorBufferTooSmall || sntpStatus == SntpErrorDnsFailure ||
+                        sntpStatus == SntpErrorAuthFailure || sntpStatus == SntpErrorNetworkFailure ),
+                      "The return value is not a valid coreSNTP Status" );
 }

--- a/test/unit-test/core_sntp_client_utest.c
+++ b/test/unit-test/core_sntp_client_utest.c
@@ -698,11 +698,6 @@ void test_Sntp_SendTimeRequest_ErrorCases()
     /* Test all cases of context with invalid members. */
     testApiForInvalidContextCases( ApiSendTimeRequest );
 
-    /* Test case when no remaining server exists to request time from. */
-    context.currentServerIndex = sizeof( testServers ) / sizeof( SntpServerInfo_t );
-    TEST_ASSERT_EQUAL( SntpErrorChangeServer,
-                       Sntp_SendTimeRequest( &context, rand() % UINT32_MAX ) );
-
     /* Reset the context member for current server to a valid value. */
     context.currentServerIndex = 0U;
 
@@ -850,12 +845,6 @@ void test_Sntp_ReceiveTimeResponse_InvalidParams()
 
     /* Test all cases of context with invalid members. */
     testApiForInvalidContextCases( ApiReceiveTimeResponse );
-
-    /* Test case when API is called even though all servers in the list have been
-     * exhausted from use . */
-    context.currentServerIndex = sizeof( testServers ) / sizeof( SntpServerInfo_t );
-    TEST_ASSERT_EQUAL( SntpErrorChangeServer,
-                       Sntp_ReceiveTimeResponse( &context, TEST_RESPONSE_TIMEOUT ) );
 }
 
 /**
@@ -1226,6 +1215,62 @@ void test_ReceiveTimeResponse_Nominal()
 }
 
 /**
+ * @brief Validate that the server rotation logic in the library wraps around to the starting
+ * of the list of servers when all servers have been exhausted. This test validates for the
+ * case when the server rotation occurs due to reception of server rejection of time request.
+ */
+void test_Sntp_ReceiveTimeResponse_ServerRotation_WrapAround_ServerRejection( void )
+{
+    /* Test server rotation wrap around when a server rejection response is received. */
+
+    /* Configure the behavior of the Sntp_DeserializeResponse API to return server rejection status. */
+    Sntp_DeserializeResponse_IgnoreAndReturn( SntpRejectedResponseChangeServer );
+
+    /* Update the context to refer to the last server in the configured list of servers to test that server
+     * rotation wraps around to the first server in the list. */
+    context.currentServerIndex = 1;
+
+    /* Configure the behavior of test's GetTime and transport receive interface functions. */
+    udpRecvRetCodes[ 0 ] = 1;                                                              /* 1st attempt to check data availability. No data received.*/
+    udpRecvRetCodes[ 1 ] = SNTP_PACKET_BASE_SIZE - 1;                                      /* 2nd attempt to check data availability. No data received. */
+    currentTimeList[ 0 ].fractions = CONVERT_MS_TO_FRACTIONS( TEST_RESPONSE_TIMEOUT / 8 ); /* 1st GetTime_t call. */
+    currentTimeList[ 1 ].fractions = CONVERT_MS_TO_FRACTIONS( TEST_RESPONSE_TIMEOUT / 4 ); /* GetTime_t call in 1st read attempt. */
+
+    /* Call the API under test. */
+    TEST_ASSERT_EQUAL( SntpRejectedResponse,
+                       Sntp_ReceiveTimeResponse( &context, TEST_RESPONSE_TIMEOUT / 2 ) );
+
+    /* Validate that the server rotation chose the next server by wrapping around to the
+     *  first server in the list. */
+    TEST_ASSERT_EQUAL( 0, context.currentServerIndex );
+}
+
+/**
+ * @brief Validate that the server rotation logic in the library wraps around to the starting
+ * of the list of servers when all servers have been exhausted. This test validates for the
+ * case when the server rotation occurs due to server response timeout.
+ */
+void test_Sntp_ReceiveTimeResponse_ServerRotation_WrapAround_ResponseTimeout( void )
+{
+    /* ================= Test server rotation wrap around when a server response times out. ==================*/
+
+    /* Update the context to refer to the last server in the configured list of servers to test that server
+     * rotation wraps around to the first server in the list. */
+    context.currentServerIndex = 1;
+
+    /* Setup test to receive no data in the first attempt and encounter server response timeout. */
+    udpRecvRetCodes[ 0 ] = 0;                                                          /* 1st call to check data availability. Receive no data. */
+    currentTimeList[ 1 ].fractions = CONVERT_MS_TO_FRACTIONS( TEST_RESPONSE_TIMEOUT ); /* 1st SntpGetTime_t call after failed attempt.. */
+    TEST_ASSERT_EQUAL( SntpErrorResponseTimeout,
+                       Sntp_ReceiveTimeResponse( &context, TEST_RESPONSE_TIMEOUT / 2 ) );
+
+    /* Validate that the server rotation chose the next server by wrapping around to the
+     *  first server in the list. */
+    TEST_ASSERT_EQUAL( 0, context.currentServerIndex );
+}
+
+
+/**
  * @brief Validates the @ref Sntp_StatusToStr function.
  */
 void test_StatusToStr( void )
@@ -1239,7 +1284,6 @@ void test_StatusToStr( void )
     TEST_ASSERT_EQUAL_STRING( "SntpInvalidResponse", Sntp_StatusToStr( SntpInvalidResponse ) );
     TEST_ASSERT_EQUAL_STRING( "SntpZeroPollInterval", Sntp_StatusToStr( SntpZeroPollInterval ) );
     TEST_ASSERT_EQUAL_STRING( "SntpErrorTimeNotSupported", Sntp_StatusToStr( SntpErrorTimeNotSupported ) );
-    TEST_ASSERT_EQUAL_STRING( "SntpErrorChangeServer", Sntp_StatusToStr( SntpErrorChangeServer ) );
     TEST_ASSERT_EQUAL_STRING( "SntpErrorDnsFailure", Sntp_StatusToStr( SntpErrorDnsFailure ) );
     TEST_ASSERT_EQUAL_STRING( "SntpErrorNetworkFailure", Sntp_StatusToStr( SntpErrorNetworkFailure ) );
     TEST_ASSERT_EQUAL_STRING( "SntpServerNotAuthenticated", Sntp_StatusToStr( SntpServerNotAuthenticated ) );

--- a/test/unit-test/core_sntp_client_utest.c
+++ b/test/unit-test/core_sntp_client_utest.c
@@ -1230,7 +1230,7 @@ void test_Sntp_ReceiveTimeResponse_ServerRotation_WrapAround_ServerRejection( vo
      * rotation wraps around to the first server in the list. */
     context.currentServerIndex = 1;
 
-    /* Configure the behavior of test's GetTime and transport receive interface functions. */
+    /* Configure the behavior of test's SntpGetTime_t and transport receive interface functions. */
     udpRecvRetCodes[ 0 ] = 1;                                                              /* 1st attempt to check data availability. No data received.*/
     udpRecvRetCodes[ 1 ] = SNTP_PACKET_BASE_SIZE - 1;                                      /* 2nd attempt to check data availability. No data received. */
     currentTimeList[ 0 ].fractions = CONVERT_MS_TO_FRACTIONS( TEST_RESPONSE_TIMEOUT / 8 ); /* 1st GetTime_t call. */


### PR DESCRIPTION
### Major changes

* Update behavior of `Sntp_ReceiveTimeResponse` API to additionally rotate server when there is a timeout in receiving server.
response. 
* Update the server rotation logic to _wrap around_ the server list once all servers have been used in the rotation occurrences. This is done to avoid the SNTP client in a device from becoming dysfunctional if such a scenario is hit.

### Other changes
* Update `calculateElapsedTimeMs` to address integer overflow issue flagged by CBMC proof, and also, better handle the corner case of NTP time overflowing between the 2 timestamps passed to it.
* Address miscellaneous MISRA violations in the library.
* Hygiene change of breaking down large test functions into smaller scopes.