### PR TITLE
Remove logic for partial transport reads and SNTP_RECV_POLLING_TIMEOUT_MS configuration

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,29 @@
+path_classifiers:
+  library:
+    - exclude: /
+extraction:
+  cpp:
+    prepare:
+      - cmake
+    configure:
+      command:
+        - cmake -S test -B build -DCMAKE_C_FLAGS='-Wall -Wextra -Werror -Wformat -Wformat-security -Warray-bounds'
+    index:
+      build_command:
+        - make -C build coverity_analysis
+
+  csharp:
+    after_prepare:
+      - false
+  go:
+    after_prepare:
+      - false
+  java:
+    after_prepare:
+      - false
+  javascript:
+    after_prepare:
+      - false
+  python:
+    after_prepare:
+      - false

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -107,6 +107,7 @@ pclienttxtime
 pclockoffset
 pcontext
 pcurrenttime
+phasresponsetimedout
 pml
 pnetworkbuffer
 pnetworkbuffer
@@ -120,6 +121,7 @@ ppacket
 pparsedresponse
 ppm
 ppollinterval
+preadstarttime
 prequestpacket
 prequesttime
 prequesttxtime
@@ -154,6 +156,7 @@ reftime
 rejectedresponsecode
 resolvednsfunc
 responsesize
+responsetimeoutms
 retryable
 rfc
 rootdelay
@@ -174,6 +177,7 @@ serverresponsetimeoutms
 servertime
 servertimesec
 servertxtime
+setsystemtimeatindex
 setsystemtimefunc
 signedfirstorderdiffrecv
 signedfirstorderdiffsend
@@ -193,6 +197,7 @@ sntperrorresponsetimeout
 sntperrortimenotsupported
 sntpinvalidresponse
 sntpnoresponse
+sntpnoresponsereceived
 sntppacketsize
 sntprejectedresponse
 sntprejectedresponsechangeserver

--- a/source/core_sntp_client.c
+++ b/source/core_sntp_client.c
@@ -770,23 +770,23 @@ static bool decideAboutReadRetry( const SntpTimestamp_t * pCurrentTime,
         *pHasResponseTimedOut = true;
 
         LogError( ( "Unable to receive response: Server response has timed out: "
-                    "RequestTime=%lus %lums, TimeoutDuration=%lums, ElapsedTime=%lu",
+                    "RequestTime=%us %ums, TimeoutDuration=%ums, ElapsedTime=%lu",
                     pRequestTime->seconds, FRACTIONS_TO_MS( pRequestTime->fractions ),
-                    responseTimeout, timeSinceRequestMs ) );
+                    responseTimeoutMs, timeSinceRequestMs ) );
     }
     /* Check whether the block time window has expired to determine whether read can be retried. */
     else if( timeElapsedInReadAttempts >= ( uint64_t ) blockTimeMs )
     {
         shouldRetry = false;
         LogDebug( ( "Did not receive server response: Read block time has expired: "
-                    "BlockTime=%lums, ResponseWaitElapsedTime=%lums",
+                    "BlockTime=%ums, ResponseWaitElapsedTime=%lums",
                     blockTimeMs, timeSinceRequestMs ) );
     }
     else
     {
         shouldRetry = true;
         LogDebug( ( "Did not receive server response: Retrying read: "
-                    "BlockTime=%lums, ResponseWaitElapsedTime=%lums, ResponseTimeout=%lu",
+                    "BlockTime=%ums, ResponseWaitElapsedTime=%lums, ResponseTimeout=%u",
                     blockTimeMs, timeSinceRequestMs, responseTimeoutMs ) );
     }
 

--- a/source/include/core_sntp_config_defaults.h
+++ b/source/include/core_sntp_config_defaults.h
@@ -53,26 +53,6 @@
 #endif
 
 /**
- * @brief The maximum duration between non-empty network reads while
- * receiving an SNTP packet via the #Sntp_ReceiveTimeResponse API function.
- *
- * When an incoming SNTP packet is detected, the transport receive function
- * may be called multiple times until all of the expected number of bytes of the
- * packet are received. This timeout represents the maximum polling duration that
- * is allowed without any data reception from the network for the incoming packet.
- *
- * If the timeout expires, the #Sntp_ReceiveTimeResponse function will return
- * #SntpErrorNetworkFailure.
- *
- * <b>Possible values:</b> Any positive 16 bit integer. Recommended to use a
- * small timeout value. <br>
- * <b>Default value:</b> `10`
- */
-#ifndef SNTP_RECV_POLLING_TIMEOUT_MS
-    #define SNTP_RECV_POLLING_TIMEOUT_MS    ( 10U )
-#endif
-
-/**
  * @brief The maximum duration between non-empty network transmissions while
  * sending an SNTP packet via the #Sntp_SendTimeRequest API function.
  *

--- a/test/cbmc/stubs/core_sntp_stubs.c
+++ b/test/cbmc/stubs/core_sntp_stubs.c
@@ -69,7 +69,6 @@ int32_t NetworkInterfaceReceiveStub( NetworkContext_t * pNetworkContext,
 
     int32_t bytesOrError;
     static size_t tries = 0;
-    static uint16_t read = 0;
 
     /* It is a bug for the application defined transport receive function to return
      * more than bytesToRecv. */
@@ -78,26 +77,12 @@ int32_t NetworkInterfaceReceiveStub( NetworkContext_t * pNetworkContext,
     if( tries < ( MAX_NETWORK_RECV_TRIES - 1 ) )
     {
         tries++;
-
-        if( bytesOrError > 0 )
-        {
-            /* Accumulating all the bytes read across multiple tries before the last try. */
-            read += bytesOrError;
-        }
     }
     else
     {
         tries = 0;
 
-        /* This ensures that all the remaining bytes are received in the last try
-         * if there are any bytes yet to be received and covers the case that
-         * SntpSuccess is returned.
-         *
-         * @note It is possible for this logic to return a negative value
-         * if the accumulated value of read over the multiple tries is
-         * greater than SNTP_PACKET_BASE_SIZE.
-         */
-        bytesOrError = SNTP_PACKET_BASE_SIZE - read;
+        bytesOrError = SNTP_PACKET_BASE_SIZE;
     }
 
     return bytesOrError;


### PR DESCRIPTION
Fix the logic of performing UDP transport read operation in the library by removing support of partial reads as UDP, being datagram protocol, does not support partial reads. Also, make hygiene change of removing redundancy of the `SNTP_RECV_POLLING_TIMEOUT_MS` macro for timeout on over receive retry operations as the `blockTimeMs` runtime parameter to the `Sntp_ReceiveTimeResponse` API provides the same utility.