### PR TITLE
Upgrade clock offset calculation to support resolution of milliseconds

### DIFF
--- a/lexicon.txt
+++ b/lexicon.txt
@@ -25,7 +25,7 @@ clienttime
 clienttimesec
 clienttxtime
 clockfreqtolerance
-clockoffsetsec
+clockoffsetms
 cmac
 com
 config

--- a/source/core_sntp_client.c
+++ b/source/core_sntp_client.c
@@ -675,13 +675,13 @@ static SntpStatus_t processServerResponse( SntpContext_t * pContext,
         {
             /* Server has responded successfully with time, and we have calculated the clock offset
              * of system clock relative to the server.*/
-            LogDebug( ( "Updating system time: ServerTime=%u %ums ClockOffset=%us",
+            LogDebug( ( "Updating system time: ServerTime=%u %ums ClockOffset=%lums",
                         parsedResponse.serverTime.seconds, FRACTIONS_TO_MS( parsedResponse.serverTime.fractions ),
-                        parsedResponse.clockOffsetSec ) );
+                        parsedResponse.clockOffsetMs ) );
 
             /* Update the system clock with the calculated offset. */
             pContext->setTimeFunc( pServer, &parsedResponse.serverTime,
-                                   parsedResponse.clockOffsetSec, parsedResponse.leapSecondType );
+                                   parsedResponse.clockOffsetMs, parsedResponse.leapSecondType );
 
             status = SntpSuccess;
         }

--- a/source/core_sntp_serializer.c
+++ b/source/core_sntp_serializer.c
@@ -237,8 +237,17 @@ static bool isZeroTimestamp( const SntpTimestamp_t * pTime )
     return( isSecondsZero && isFractionsZero );
 }
 
-#define FRACTIONS_TO_MS( fractions ) \
-    ( fractions / ( 1000U * SNTP_FRACTION_VALUE_PER_MICROSECOND ) )
+/**
+ * @brief Utility to convert the "fractions" part of an SNTP timestamp to milliseconds
+ * duration of time.
+ * @param[in] fractions The fractions value.
+ *
+ * @return The milliseconds equivalent of the @p fractions value.
+ */
+static uint32_t fractionsToMs( uint32_t fractions )
+{
+    return( fractions / ( 1000U * SNTP_FRACTION_VALUE_PER_MICROSECOND ) );
+}
 
 /**
  * @brief Utility to safely calculate difference between server and client timestamps and
@@ -263,8 +272,8 @@ static int64_t safeTimeDifference( const SntpTimestamp_t * pServerTime,
     int64_t eraAdjustedDiff = 0;
 
     /* Convert the timestamps into 64 bit signed integer values of milliseconds. */
-    int64_t serverTime = ( ( int64_t ) pServerTime->seconds * 1000 ) + ( int64_t ) FRACTIONS_TO_MS( pServerTime->fractions );
-    int64_t clientTime = ( ( int64_t ) pClientTime->seconds * 1000 ) + ( int64_t ) FRACTIONS_TO_MS( pClientTime->fractions );
+    int64_t serverTime = ( ( int64_t ) pServerTime->seconds * 1000 ) + ( int64_t ) fractionsToMs( pServerTime->fractions );
+    int64_t clientTime = ( ( int64_t ) pClientTime->seconds * 1000 ) + ( int64_t ) fractionsToMs( pClientTime->fractions );
 
     /* The difference between the 2 timestamps is calculated by determining the whether the timestamps
      * are present in the same NTP era or adjacent NTP eras (i.e. the NTP timestamp overflow case). */

--- a/source/core_sntp_serializer.c
+++ b/source/core_sntp_serializer.c
@@ -121,16 +121,17 @@
  * determined based on comparing first order difference values between all possible NTP era
  * configurations of the systems.
  */
-#define CLOCK_OFFSET_MAX_TIME_DIFFERENCE    ( ( int64_t ) INT32_MAX + 1 )
+#define CLOCK_OFFSET_MAX_TIME_DIFFERENCE    ( ( ( ( int64_t ) INT32_MAX + 1 ) * 1000 ) )
 
 /**
- * @brief Macro to represent the total seconds that are represented in an NTP era period.
- * The macro value represents a duration of ~136 years.
+ * @brief Macro to represent the total number of milliseconds that are represented in an
+ * NTP era period. This macro represents a duration of ~136 years.
  *
- * @note As the "seconds" part of an NTP timestamp is represented in unsigned 32 bit width,
- * the total number of seconds it can represent is 2^32, i.e. (UINT32_MAX + 1).
+ * @note Rationale for calculation: The "seconds" part of an NTP timestamp is represented in
+ * unsigned 32 bit width, thus, the total range of seconds it represents is 2^32,
+ * i.e. (UINT32_MAX + 1).
  */
-#define TOTAL_SECONDS_IN_NTP_ERA            ( ( int64_t ) ( UINT32_MAX ) + ( int64_t ) 1 )
+#define TOTAL_MILLISECONDS_IN_NTP_ERA       ( ( ( int64_t ) UINT32_MAX + 1 ) * 1000 )
 
 /**
  * @brief Structure representing an SNTP packet header.
@@ -212,8 +213,7 @@ static uint32_t readWordFromNetworkByteOrderMemory( const uint32_t * ptr )
  */
 static int64_t absoluteOf( int64_t value )
 {
-    return ( value >= ( int64_t ) 0 ) ?
-           value : ( ( int64_t ) 0 - value );
+    return ( value >= 0 ) ? value : ( ( int64_t ) 0 - value );
 }
 
 /**
@@ -237,10 +237,13 @@ static bool isZeroTimestamp( const SntpTimestamp_t * pTime )
     return( isSecondsZero && isFractionsZero );
 }
 
+#define FRACTIONS_TO_MS( fractions ) \
+    ( fractions / ( 1000U * SNTP_FRACTION_VALUE_PER_MICROSECOND ) )
+
 /**
- * @brief Utility to safely calculate difference between server and client timestamps of
- * unsigned integer type and return the value as a signed 64 bit integer. The calculated value
- * represents the effective subtraction as ( @p serverTimeSec - @p clientTimeSec ).
+ * @brief Utility to safely calculate difference between server and client timestamps and
+ * return the difference in the resolution of milliseconds as a signed 64 bit integer.
+ * The calculated value represents the effective subtraction as ( @p serverTimeSec - @p clientTimeSec ).
  *
  * @note This utility SUPPORTS the cases of server and client timestamps being in different NTP eras,
  * and ASSUMES that the server and client systems are within 68 years of each other.
@@ -249,20 +252,22 @@ static bool isZeroTimestamp( const SntpTimestamp_t * pTime )
  * 2. server timestamp one era ahead, and 3. client timestamp being one era ahead), and determines
  * the NTP era configuration by choosing the difference value of the smallest absolute value.
  *
- * @param[in] serverTimeSec The "seconds" part of the server timestamp.
- * @param[in] clientTimeSec The "seconds" part of the client timestamp.
+ * @param[in] serverTime The server timestamp.
+ * @param[in] clientTime The client timestamp.
  *
  * @return The calculated difference between server and client times as a signed 64 bit integer.
  */
-static int64_t safeTimeDifference( uint32_t serverTimeSec,
-                                   uint32_t clientTimeSec )
+static int64_t safeTimeDifference( const SntpTimestamp_t * pServerTime,
+                                   const SntpTimestamp_t * pClientTime )
 {
     int64_t eraAdjustedDiff = 0;
 
-    /* Convert the "seconds" part of timestamps to signed 64 bit integer along with determining
-     * relative NTP era presence of server time relative to client time. */
-    int64_t serverTime = ( int64_t ) serverTimeSec;
-    int64_t clientTime = ( int64_t ) clientTimeSec;
+    /* Convert the timestamps into 64 bit signed integer values of milliseconds. */
+    int64_t serverTime = ( ( int64_t ) pServerTime->seconds * 1000 ) + ( int64_t ) FRACTIONS_TO_MS( pServerTime->fractions );
+    int64_t clientTime = ( ( int64_t ) pClientTime->seconds * 1000 ) + ( int64_t ) FRACTIONS_TO_MS( pClientTime->fractions );
+
+    /* The difference between the 2 timestamps is calculated by determining the whether the timestamps
+     * are present in the same NTP era or adjacent NTP eras (i.e. the NTP timestamp overflow case). */
 
     /* First, calculate the first order time difference assuming that server and client times
      * are in the same NTP era. */
@@ -274,20 +279,18 @@ static int64_t safeTimeDifference( uint32_t serverTimeSec,
 
     /* If the absolute difference value is 2^31 seconds, it means that the server and client times are
      * away by exactly half the range of SNTP timestamp "second" values representable in unsigned 32 bits.
-     * In this case, the NTP era presence of the server and client systems cannot be determined just
-     * by comparing the first order differences of different era configurations, thus, we will ASSUME
-     * that the server time is AHEAD of client time.
-     * Note: As a signed 32 bit integer cannot represent value of 2^31 (or 2147483648 ) as a positive
-     * value, but we are assuming that the server is ahead of client, thereby, generating a positive clock offset
-     *, we will return the maximum value representable by signed 2^31, i.e. 2147483647, resulting in
-     * an inaccuracy of 1 second in the clock-offset value.
+     * In such a case, irrespective of whether the 2 systems exist in the same or adjacent NTP eras, the
+     * time difference calculated between the systems will ALWAYS yield the same value when viewed from
+     * all NTP era configurations of the times.
+     * For such a case, we will ASSUME that the server time is AHEAD of client time, and thus, generate
+     * a positive clock-offset value.
      */
     if( absSameEraDiff == CLOCK_OFFSET_MAX_TIME_DIFFERENCE )
     {
         /* It does not matter whether server and client are in the same era for this
          * special case as the difference value for both same and adjacent eras will yield
          * the same absolute value of 2^31.*/
-        eraAdjustedDiff = INT32_MAX;
+        eraAdjustedDiff = CLOCK_OFFSET_MAX_TIME_DIFFERENCE;
     }
     else
     {
@@ -298,12 +301,12 @@ static int64_t safeTimeDifference( uint32_t serverTimeSec,
          * (1. both timestamps in same era, 2. server time one era ahead, 3. client time one era ahead)
          * and choosing the NTP era configuration that has the smallest first order difference value.
          */
-        int64_t diffWithServerEraAdjustment = serverTime + TOTAL_SECONDS_IN_NTP_ERA -
-                                              clientTime;                                /* This helps determine whether server is an
-                                                                                          * era ahead of client time. */
+        int64_t diffWithServerEraAdjustment = serverTime + TOTAL_MILLISECONDS_IN_NTP_ERA -
+                                              clientTime;                                     /* This helps determine whether server is an
+                                                                                               * era ahead of client time. */
         int64_t diffWithClientEraAdjustment = serverTime -
-                                              ( TOTAL_SECONDS_IN_NTP_ERA + clientTime ); /* This helps determine whether server is an
-                                                                                          * era behind of client time. */
+                                              ( TOTAL_MILLISECONDS_IN_NTP_ERA + clientTime ); /* This helps determine whether server is an
+                                                                                               * era behind of client time. */
 
         /* Store the absolute value equivalents of all the time difference configurations
          * for easier comparison to smallest value from them. */
@@ -385,26 +388,19 @@ static int64_t safeTimeDifference( uint32_t serverTimeSec,
  * packet. This is the same as "T3" in the above diagram.
  * @param[in] pClientRxTime The system time of receiving the SNTP response
  * from the server. This is the same as "T4" in the above diagram.
- * @param[out] pClockOffset The calculated offset value of the system clock
- * relative to the server time, if the system clock is within 34 years of
- * server time; otherwise, the seconds part of clock offset is set to
- * #SNTP_CLOCK_OFFSET_OVERFLOW.
- *
- * @return #SntpSuccess if clock-offset is calculated; #SntpClockOffsetOverflow
- * otherwise for inability to calculate from arithmetic overflow.
+ * @param[out] pClockOffset This will be filled with the calculated offset value
+ * of the system clock relative to the server time with the assumption that the
+ * system clock is within 68 years of server time.
  */
-static SntpStatus_t calculateClockOffset( const SntpTimestamp_t * pClientTxTime,
-                                          const SntpTimestamp_t * pServerRxTime,
-                                          const SntpTimestamp_t * pServerTxTime,
-                                          const SntpTimestamp_t * pClientRxTime,
-                                          int32_t * pClockOffset )
+static void calculateClockOffset( const SntpTimestamp_t * pClientTxTime,
+                                  const SntpTimestamp_t * pServerRxTime,
+                                  const SntpTimestamp_t * pServerTxTime,
+                                  const SntpTimestamp_t * pClientRxTime,
+                                  int64_t * pClockOffset )
 {
-    SntpStatus_t status = SntpSuccess;
-
     /* Variable for storing the first-order difference between timestamps. */
     int64_t firstOrderDiffSend = 0;
     int64_t firstOrderDiffRecv = 0;
-    int64_t clockOffSet = 0;
 
     assert( pClientTxTime != NULL );
     assert( pServerRxTime != NULL );
@@ -414,24 +410,18 @@ static SntpStatus_t calculateClockOffset( const SntpTimestamp_t * pClientTxTime,
 
     /* Perform first order difference of timestamps on the network send path i.e. T2 - T1.
      * Note: The calculated difference value will always represent years in the range of
-     *[-68 years, +68 years] i.e. a value in the range of [INT32_MIN, INT32_MAX]. */
-    firstOrderDiffSend = safeTimeDifference( pServerRxTime->seconds, pClientTxTime->seconds );
+     *[-68 years, +68 years]. */
+    firstOrderDiffSend = safeTimeDifference( pServerRxTime, pClientTxTime );
 
-    /* Perform first order difference of timestamps on the network receive path i.e. T3 - T4 .
+    /* Perform first order difference of timestamps on the network receive path i.e. T3 - T4.
      * Note: The calculated difference value will always represent years in the range of
-     *[-68 years, +68 years] i.e. a value in the range of [INT32_MIN, INT32_MAX]. */
-    firstOrderDiffRecv = safeTimeDifference( pServerTxTime->seconds, pClientRxTime->seconds );
+     *[-68 years, +68 years]. */
+    firstOrderDiffRecv = safeTimeDifference( pServerTxTime, pClientRxTime );
 
     /* Now calculate the system clock-offset relative to server time as the average of the
      * first order difference of timestamps in both directions of network path.
      * Note: This will ALWAYS represent offset in the range of [-68 years, +68 years]. */
-    clockOffSet = ( firstOrderDiffSend + firstOrderDiffRecv ) / 2;
-
-    /* We can represent the calculated clock-offset as signed 32 integer as the calculated
-     * clock offset will ALWAYS be in the signed 32 integer range. */
-    *pClockOffset = ( int32_t ) clockOffSet;
-
-    return status;
+    *pClockOffset = ( firstOrderDiffSend + firstOrderDiffRecv ) / 2;
 }
 
 /**
@@ -538,8 +528,7 @@ static SntpStatus_t parseValidSntpResponse( const SntpPacket_t * pResponsePacket
 
         /* Extract information of any upcoming leap second from the response. */
         pParsedResponse->leapSecondType = leapIndicatorTypeMap[
-            ( pResponsePacket->leapVersionMode
-              >> SNTP_LEAP_INDICATOR_LSB_POSITION ) ];
+            ( pResponsePacket->leapVersionMode >> SNTP_LEAP_INDICATOR_LSB_POSITION ) ];
 
         /* Store the "receive" time in SNTP response packet in host order. */
         serverRxTime.seconds =
@@ -549,11 +538,11 @@ static SntpStatus_t parseValidSntpResponse( const SntpPacket_t * pResponsePacket
 
         /* Calculate system clock offset relative to server time, if possible, within
          * the 64 bit integer width of the SNTP timestamp. */
-        status = calculateClockOffset( pRequestTxTime,
-                                       &serverRxTime,
-                                       &pParsedResponse->serverTime,
-                                       pResponseRxTime,
-                                       &pParsedResponse->clockOffsetSec );
+        calculateClockOffset( pRequestTxTime,
+                              &serverRxTime,
+                              &pParsedResponse->serverTime,
+                              pResponseRxTime,
+                              &pParsedResponse->clockOffsetMs );
     }
 
     return status;

--- a/source/include/core_sntp_client.h
+++ b/source/include/core_sntp_client.h
@@ -116,8 +116,8 @@ typedef void ( * SntpGetTime_t )( SntpTimestamp_t * pCurrentTime );
  *
  * @param[in] pTimeServer The time server used to request time.
  * @param[in] pServerTime The current time returned by the @p pTimeServer.
- * @param[in] clockOffSetSec The calculated clock offset of the system relative
- * to the server time.
+ * @param[in] clockOffSetMs The calculated clock offset (in milliseconds) of the
+ * system relative to the server time.
  * @param[in] leapSecondInfo Information about whether there is about an upcoming
  * leap second adjustment of insertion or deletion in the last minute before midnight
  * on the last day of the current month. For more information on leap seconds, refer
@@ -125,20 +125,21 @@ typedef void ( * SntpGetTime_t )( SntpTimestamp_t * pCurrentTime );
  * on the accuracy requirements of the system clock, the user can choose to account
  * for the leap second or ignore it in their system clock update logic.
  *
- * @note The user can use either a "step" or "slew" clock discipline methodology
- * depending on the application needs.
- * If the application requires a smooth time continuum of system time is required,
- * then the "slew" discipline methodology can be used with the clock offset value,
- * @p clockOffSetSec, to apply correction to the system clock with a "slew rate"
- * (that is higher than the SNTP polling rate).
+ * @note If the @p clockOffsetMs is positive, then the system time is BEHIND the server time,
+ * and if the @p clockOffsetMs, the system time is AHEAD of the server time. To correct the
+ * system time, the user can use either of "step", "slew" OR combination of the two clock
+ * discipline methodologies depending on the application needs.
+ * If the application requires a smooth time continuum of system time, then the "slew"
+ * discipline methodology can be used with the clock offset value, @p clockOffSetMs, to correct
+ * the system clock gradually with a "slew rate".
  * If the application can accept sudden jump in time (forward or backward), then
  * the "step" discipline methodology can be used to directly update the system
- * clock with the current server time, @p pServerTime, every time the coreSNTP
- * library calls the interface.
+ * clock with the current server time, @p pServerTime, every time the coreSNTP library
+ * calls the interface.
  */
 typedef void ( * SntpSetTime_t )( const SntpServerInfo_t * pTimeServer,
                                   const SntpTimestamp_t * pServerTime,
-                                  int32_t clockOffsetSec,
+                                  int64_t pClockOffsetMs,
                                   SntpLeapSecondInfo_t leapSecondInfo );
 
 /**

--- a/source/include/core_sntp_client.h
+++ b/source/include/core_sntp_client.h
@@ -139,7 +139,7 @@ typedef void ( * SntpGetTime_t )( SntpTimestamp_t * pCurrentTime );
  */
 typedef void ( * SntpSetTime_t )( const SntpServerInfo_t * pTimeServer,
                                   const SntpTimestamp_t * pServerTime,
-                                  int64_t pClockOffsetMs,
+                                  int64_t clockOffsetMs,
                                   SntpLeapSecondInfo_t leapSecondInfo );
 
 /**

--- a/source/include/core_sntp_serializer.h
+++ b/source/include/core_sntp_serializer.h
@@ -297,10 +297,15 @@ typedef struct SntpResponse
     uint32_t rejectedResponseCode;
 
     /**
-     * @brief The offset (in seconds) of the system clock relative to the
-     * server time calculated from timestamps in the client SNTP request and
-     * server SNTP response packets. This information can be used to synchronize
-     * the system clock with a "slew" or "step" correction approach.
+     * @brief The offset (in milliseconds) of the system clock relative to the server time
+     * calculated from timestamps in the client SNTP request and server SNTP response packets.
+     * If the the system time is BEHIND the server time, then the clock-offset value is > 0.
+     * If the system time is AHEAD of the server time, then the clock-offset value is < 0.
+     *
+     * @note This information can be used to synchronize the system clock with a "slew",
+     * "step" OR combination of the two clock correction methodologies depending on the degree
+     *  of system clock drift (represented by the clock-offset) and the application's
+     * tolerance for system clock error.
      *
      * @note The library calculates the clock-offset value using the On-Wire
      * protocol suggested by the NTPv4 specification. For more information,
@@ -315,7 +320,7 @@ typedef struct SntpResponse
      * seconds apart, the library ASSUMES that the server time is ahead of the client
      * time, and return the clock-offset value of INT32_MAX.
      */
-    int32_t clockOffsetSec;
+    int64_t clockOffsetMs;
 } SntpResponseData_t;
 
 

--- a/test/cbmc/include/core_sntp_stubs.h
+++ b/test/cbmc/include/core_sntp_stubs.h
@@ -141,11 +141,11 @@ void GetTimeFuncStub( SntpTimestamp_t * pCurrentTime );
  *
  * @param[in] pTimeServer The time server used to request time.
  * @param[in] pServerTime The current time returned by the @p pTimeServer.
- * @param[in] clockOffSetSec The calculated clock offset of the system relative
+ * @param[in] clockOffSetMs The calculated clock offset of the system relative
  * to the server time.
  */
 void SetTimeFuncStub( const SntpServerInfo_t * pTimeServer,
                       const SntpTimestamp_t * pServerTime,
-                      int32_t clockOffsetSec );
+                      int64_t clockOffsetMs );
 
 #endif /* ifndef CORE_SNTP_CBMC_STUBS_H_ */

--- a/test/cbmc/stubs/core_sntp_stubs.c
+++ b/test/cbmc/stubs/core_sntp_stubs.c
@@ -194,7 +194,7 @@ void GetTimeFuncStub( SntpTimestamp_t * pCurrentTime )
 
 void SetTimeFuncStub( const SntpServerInfo_t * pTimeServer,
                       const SntpTimestamp_t * pServerTime,
-                      int32_t clockOffsetSec )
+                      int64_t clockOffsetMs )
 {
     __CPROVER_assert( pTimeServer != NULL,
                       "SetTimeFuncStub pTimeServer is NULL." );

--- a/test/unit-test/core_sntp_client_utest.c
+++ b/test/unit-test/core_sntp_client_utest.c
@@ -108,7 +108,7 @@ static SntpStatus_t validateServerAuthRetCode = SntpSuccess;
 /* Output parameter for mock of Sntp_DeserializeResponse API. */
 static SntpResponseData_t mockResponseData =
 {
-    .clockOffsetSec       = 1000,
+    .clockOffsetMs        = 1000,
     .leapSecondType       = NoLeapSecond,
     .rejectedResponseCode = SNTP_KISS_OF_DEATH_CODE_NONE,
     .serverTime           =
@@ -150,12 +150,12 @@ static void getTime( SntpTimestamp_t * pCurrentTime )
 /* Test definition of the @ref SntpSetTime_t interface. */
 static void setTime( const SntpServerInfo_t * pTimeServer,
                      const SntpTimestamp_t * pServerTime,
-                     int32_t clockOffsetSec,
+                     int64_t clockOffsetMs,
                      SntpLeapSecondInfo_t leapSecondInfo )
 {
     TEST_ASSERT_NOT_NULL( pTimeServer );
     TEST_ASSERT_NOT_NULL( pServerTime );
-    TEST_ASSERT_EQUAL( mockResponseData.clockOffsetSec, clockOffsetSec );
+    TEST_ASSERT_EQUAL( mockResponseData.clockOffsetMs, clockOffsetMs );
     TEST_ASSERT_EQUAL( mockResponseData.leapSecondType, leapSecondInfo );
     TEST_ASSERT_EQUAL_MEMORY( &mockResponseData.serverTime, pServerTime, sizeof( SntpTimestamp_t ) );
 }

--- a/test/unit-test/core_sntp_serializer_utest.c
+++ b/test/unit-test/core_sntp_serializer_utest.c
@@ -156,7 +156,7 @@ static void testClockOffsetCalculation( SntpTimestamp_t * clientTxTime,
                                         SntpTimestamp_t * serverTxTime,
                                         SntpTimestamp_t * clientRxTime,
                                         SntpStatus_t expectedStatus,
-                                        int32_t expectedClockOffset )
+                                        int64_t expectedClockOffset )
 {
     /* Update the response packet with the server time. */
     addTimestampToResponseBuffer( clientTxTime,
@@ -178,7 +178,7 @@ static void testClockOffsetCalculation( SntpTimestamp_t * clientTxTime,
 
     /* Make sure that the API has indicated in the output parameter that
      * clock-offset could not be calculated. */
-    TEST_ASSERT_EQUAL( expectedClockOffset, parsedData.clockOffsetSec );
+    TEST_ASSERT_EQUAL( ( int64_t ) expectedClockOffset * 1000, parsedData.clockOffsetMs );
 
     /* Validate other fields in the output parameter. */
     TEST_ASSERT_EQUAL( 0, memcmp( &parsedData.serverTime, serverTxTime, sizeof( SntpTimestamp_t ) ) );
@@ -566,14 +566,14 @@ void test_DeserializeResponse_AcceptedResponse_ClockOffset_Edge_Cases( void )
     testClockOffsetCalculation( &clientTime, &serverTime,
                                 &serverTime, &clientTime,
                                 SntpSuccess,
-                                INT32_MAX );
+                                ( int64_t ) INT32_MAX + 1 );
     /* Test when "Server Time - Client Time" results in positive value. */
     serverTime.seconds = UINT32_MAX;
     clientTime.seconds = serverTime.seconds - INT32_MAX - 1;
     testClockOffsetCalculation( &clientTime, &serverTime,
                                 &serverTime, &clientTime,
                                 SntpSuccess,
-                                INT32_MAX );
+                                ( int64_t ) INT32_MAX + 1 );
 
     /* Reset client time to UINT32_MAX */
     clientTime.seconds = UINT32_MAX;
@@ -732,7 +732,7 @@ void test_DeserializeResponse_AcceptedResponse_LeapSecond( void )
                                                                   &parsedData ) );                        \
                                                                                                           \
         /* As the clock and server times are same, the clock offset, should be zero. */                   \
-        TEST_ASSERT_EQUAL( 0, parsedData.clockOffsetSec );                                                \
+        TEST_ASSERT_EQUAL( 0, parsedData.clockOffsetMs );                                                 \
                                                                                                           \
         /* Validate other fields in the output parameter. */                                              \
         TEST_ASSERT_EQUAL( 0, memcmp( &parsedData.serverTime, &serverTime, sizeof( SntpTimestamp_t ) ) ); \


### PR DESCRIPTION
To support applications that require device clock accuracy in the order of milliseconds, thiss PR updates the clock-offset calculation logic of the library to return the value in milliseconds instead of seconds. This allows clock-offset calculation in the range of milliseconds (for high clock accuracy use-cases) to 68 years (for case like a device boot-up without RTC module or hard-coded time in flash)