### PR TITLE
Update README with link to doxygen

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This library has gone through code quality checks including verification that no
 
 See memory requirements for this library [here](./docs/doxygen/include/size_table.md).
 
+### Documentation
+
+The API reference documentation for the coreSNTP library version released in [FreeRTOS/FreeRTOS](https://github.com/FreeRTOS/FreeRTOS) can be viewed from the [freertos.org website](https://freertos.org/coresntp/index.html).
+
 ## Cloning this repository
 This repo uses [Git Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) to bring in dependent components.
 


### PR DESCRIPTION
Add link to the library doxygen documentation in README.md for ease of customer access.