### PR TITLE
MISRA Compliance Update

### DIFF
--- a/MISRA.md
+++ b/MISRA.md
@@ -2,21 +2,17 @@
 
 The coreSNTP library files conform to the [MISRA C:2012](https://www.misra.org.uk)
 guidelines, with some noted exceptions. Compliance is checked with Coverity static analysis.
-Deviations from the MISRA standard are listed below:
+The specific deviations, suppressed inline, are listed below.
 
-### Ignored by [Coverity Configuration](https://github.com/aws/aws-iot-device-sdk-embedded-C/blob/main/tools/coverity/misra.config)
-| Deviation | Category | Justification |
-| :-: | :-: | :-: |
-| Directive 4.9 | Advisory | Allow inclusion of function like macros. The `assert` macro is used throughout the library for parameter validation, and logging is done using function like macros. |
-| Rule 2.4 | Advisory | Allow unused tags. Some compilers warn if types are not tagged. |
-| Rule 2.5 | Advisory | Allow unused macros. Library headers may define macros intended for the application's use, but are not used by a specific file. |
-| Rule 3.1 | Required | Allow nested comments. C++ style `//` comments are used in example code within Doxygen documentation blocks. |
-| Rule 11.5 | Advisory | Allow casts from `void *`. The library casts the byte array information received network to a `SntpPacket_t *` for parsing SNTP packet. |
-
-### Flagged by Coverity
-| Deviation | Category | Justification |
-| :-: | :-: | :-: |
-| Rule 8.7 | Advisory | API functions are not used by the library outside of the files they are defined; however, they must be externally visible in order to be used by an application. |
+Additionally, [MISRA configuration file](https://github.com/FreeRTOS/coreSNTP/blob/main/tools/coverity/misra.config) contains the project wide deviations.
 
 ### Suppressed with Coverity Comments
-*None.*
+To find the violation references in the source files run grep on the source code
+with ( Assuming rule 11.5 violation; with justification in point 1 ):
+```
+grep 'MISRA Ref 11.5.1' . -rI
+```
+#### Rule 11.5
+_Ref 11.5.1_
+- MISRA C-2012 Rule 11.5 Allow casts from `void *`. The library casts the byte
+    array information received network to a `SntpPacket_t *` for parsing SNTP packet.

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -34,6 +34,7 @@ configs
 const
 copydoc
 coresntp
+coverity
 css
 currenttimelist
 de

--- a/source/core_sntp_serializer.c
+++ b/source/core_sntp_serializer.c
@@ -628,6 +628,9 @@ SntpStatus_t Sntp_SerializeRequest( SntpTimestamp_t * pRequestTime,
     }
     else
     {
+        /* MISRA Ref 11.5.1 [Void pointer assignment] */
+        /* More details at: https://github.com/FreeRTOS/coreSNTP/blob/main/MISRA.md#rule-115 */
+        /* coverity[misra_c_2012_rule_11_5_violation] */
         SntpPacket_t * pRequestPacket = ( SntpPacket_t * ) pBuffer;
 
         /* Fill the buffer with zero as most fields are zero for a standard SNTP
@@ -670,6 +673,9 @@ SntpStatus_t Sntp_DeserializeResponse( const SntpTimestamp_t * pRequestTime,
                                        SntpResponseData_t * pParsedResponse )
 {
     SntpStatus_t status = SntpSuccess;
+    /* MISRA Ref 11.5.1 [Void pointer assignment] */
+    /* More details at: https://github.com/FreeRTOS/coreSNTP/blob/main/MISRA.md#rule-115 */
+    /* coverity[misra_c_2012_rule_11_5_violation] */
     const SntpPacket_t * pResponsePacket = ( const SntpPacket_t * ) pResponseBuffer;
 
     if( ( pRequestTime == NULL ) || ( pResponseRxTime == NULL ) ||

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,6 +47,9 @@ target_include_directories( coverity_analysis
 # Build SNTP library target without custom config dependency.
 target_compile_definitions( coverity_analysis PUBLIC SNTP_DO_NOT_USE_CUSTOM_CONFIG=1 )
 
+# Build without debug enabled when performing static analysis
+target_compile_options(coverity_analysis PUBLIC -DNDEBUG )
+
 #  ==================================== Code Example Build ====================================
 
 if(${BUILD_CODE_EXAMPLE})

--- a/tools/coverity/misra.config
+++ b/tools/coverity/misra.config
@@ -7,16 +7,8 @@
     deviations : [
         // Disable the following rules.
         {
-            deviation: "Directive 4.8",
-            reason: "Allow inclusion of unused types. Header files for coreSNTP, which are needed by all files, define types that are not used by the agent."
-        },
-        {
             deviation: "Directive 4.9",
             reason: "Allow inclusion of function like macros. Asserts and logging are done using function like macros."
-        },
-        {
-            deviation: "Rule 2.3",
-            reason: "Allow unused types. coreSNTP Library headers define types intended for the application's use, but are not used by the agent files."
         },
         {
             deviation: "Rule 2.4",
@@ -31,8 +23,8 @@
             reason: "Allow nested comments. Documentation blocks contain comments for example code."
         },
         {
-            deviation: "Rule 11.5",
-            reason: "Allow casts from void *. coreSNTP library casts request and response buffers are cast to an internal type representing SNTP packet."
-        }
+            deviation: "Rule 8.7",
+            reason: "API functions are not used by library. They must be externally visible in order to be used by the application."
+        },
     ]
 }


### PR DESCRIPTION
Swapping to inline suppression for a rule that is only being violated twice. Updated the MISRA.md file to match the new format. Added DNDEBUG to the coverity_analysis target.