### PR TITLE
Move user config include from header to C files

### DIFF
--- a/source/core_sntp_client.c
+++ b/source/core_sntp_client.c
@@ -32,6 +32,8 @@
 /* SNTP client library API include. */
 #include "core_sntp_client.h"
 
+#include "core_sntp_config_defaults.h"
+
 /**
  * @brief Utility to convert fractions part of SNTP timestamp to milliseconds.
  *

--- a/source/core_sntp_serializer.c
+++ b/source/core_sntp_serializer.c
@@ -33,6 +33,8 @@
 /* Include API header. */
 #include "core_sntp_serializer.h"
 
+#include "core_sntp_config_defaults.h"
+
 /**
  * @brief The version of SNTP supported by the coreSNTP library by complying
  * with the SNTPv4 specification defined in [RFC 4330](https://tools.ietf.org/html/rfc4330).

--- a/source/include/core_sntp_client.h
+++ b/source/include/core_sntp_client.h
@@ -40,18 +40,6 @@
 /* Include coreSNTP Serializer header. */
 #include "core_sntp_serializer.h"
 
-/* SNTP_DO_NOT_USE_CUSTOM_CONFIG allows building the SNTP library
- * without a custom config. If a custom config is provided, the
- * SNTP_DO_NOT_USE_CUSTOM_CONFIG macro should not be defined. */
-#ifndef SNTP_DO_NOT_USE_CUSTOM_CONFIG
-    /* Include custom config file before other headers. */
-    #include "core_sntp_config.h"
-#endif
-
-/* Include config defaults header to get default values of configs not
- * defined in core_sntp_config.h file. */
-#include "core_sntp_config_defaults.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {

--- a/source/include/core_sntp_config_defaults.h
+++ b/source/include/core_sntp_config_defaults.h
@@ -52,6 +52,13 @@
     #define SNTP_DO_NOT_USE_CUSTOM_CONFIG
 #endif
 
+/* SNTP_DO_NOT_USE_CUSTOM_CONFIG allows building the SNTP library
+ * without a custom config. If a custom config is provided, the
+ * SNTP_DO_NOT_USE_CUSTOM_CONFIG macro should not be defined. */
+#ifndef SNTP_DO_NOT_USE_CUSTOM_CONFIG
+    #include "core_sntp_config.h"
+#endif
+
 /**
  * @brief Macro that is called in the SNTP library for logging "Error" level
  * messages.


### PR DESCRIPTION
This prevents the contents of the user config from affecting all files using coreSNTP instead of just coreSNTP source files.