### PR TITLE
Logging Print Formatter Fix

### DIFF
--- a/.github/.cSpellWords.txt
+++ b/.github/.cSpellWords.txt
@@ -20,6 +20,7 @@ coverity
 ctest
 fracs
 lcov
+ldms
 lums
 misra
 sinclude

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,22 +198,8 @@ jobs:
           config: .github/memory_statistics_config.json
           check_against: docs/doxygen/include/size_table.md
 
-  proof_ci_cbmc_runner:
-    if: ${{ github.event.repository.owner }} == "FreeRTOS"
-    runs-on: cbmc_ubuntu-latest_16-core
-    steps:
-      - name: Set up CBMC runner
-        uses: FreeRTOS/CI-CD-Github-Actions/set_up_cbmc_runner@main
-        with:
-          cbmc_version: "5.61.0"
-          cbmc_viewer_version: "3.5"
-      - name: Run CBMC
-        uses: FreeRTOS/CI-CD-Github-Actions/run_cbmc@main
-        with:
-          proofs_dir: test/cbmc/proofs
-
-  proof_ci_ubuntu_runner:
-    if: ${{ github.event.repository.owner }} != "FreeRTOS"
+  proof_ci:
+    if: ${{ github.event.pull_request }} || ${{ github.event.workflow }}
     runs-on: ubuntu-20.04
     steps:
       - name: Set up CBMC runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,14 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+
 jobs:
   build-check:
     runs-on: ubuntu-latest
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v3
+
       - name: Build Library in Debug mode
         run: |
           cmake -S test -B build/ \
@@ -18,6 +20,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Debug \
           -DCMAKE_C_FLAGS='-O0 -Wall -Wextra -Werror -Wformat -Wformat-security -Warray-bounds'
           make -C build/ coverity_analysis -j8
+
       - name: Build Library in Release mode
         run: |
           rm -rf ./build
@@ -25,15 +28,18 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_C_FLAGS='-Wall -Wextra -Werror -DNDEBUG -Wformat -Wformat-security -Warray-bounds'
           make -C build/ coverity_analysis -j8
+
   build-code-example:
     runs-on: ubuntu-latest
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v3
+
       - name: Build Code Example used in Doxygen
         run: |
           cmake -S test -B Build -DBUILD_CODE_EXAMPLE=ON
           make -C Build code_example_posix -j8
+
   unittest-with-sanitizer:
     runs-on: ubuntu-latest
     steps:
@@ -58,16 +64,19 @@ jobs:
           -DBUILD_UNIT_TESTS=ON \
           -DCMAKE_C_FLAGS="${CFLAGS}"
           make -C build all -j8
+
       - name: Run unit tests with sanitizer
         run: |
           cd build
           ctest -E system --output-on-failure
           cd ..
+
   unittest-for-coverage:
     runs-on: ubuntu-latest
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v3
+
       - name: Build
         run: |
           sudo apt-get install -y lcov sed
@@ -78,21 +87,25 @@ jobs:
           -DBUILD_UNIT_TESTS=ON \
           -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -Wno-error=pedantic -Wno-variadic-macros -DLOGGING_LEVEL_DEBUG=1'
           make -C build/ all
+
       - name: Test
         run: |
           cd build/
           ctest -E system --output-on-failure
           cd ..
+
       - name: Run Coverage
         run: |
           make -C build/ coverage
           declare -a EXCLUDE=("\*test\*" "\*CMakeCCompilerId\*" "\*mocks\*")
           echo ${EXCLUDE[@]} | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
+
       - name: Check Coverage
         uses: FreeRTOS/CI-CD-Github-Actions/coverage-cop@main
         with:
           coverage-file: ./build/coverage.info
+
   complexity:
     runs-on: ubuntu-latest
     steps:
@@ -170,6 +183,7 @@ jobs:
         uses: FreeRTOS/CI-CD-Github-Actions/doxygen@main
         with:
           path: ./
+
   memory_statistics:
     runs-on: ubuntu-latest
     steps:
@@ -183,6 +197,7 @@ jobs:
         with:
           config: .github/memory_statistics_config.json
           check_against: docs/doxygen/include/size_table.md
+
   proof_ci:
     if: ${{ github.event.pull_request }}
     runs-on: cbmc_ubuntu-latest_16-core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,9 +198,23 @@ jobs:
           config: .github/memory_statistics_config.json
           check_against: docs/doxygen/include/size_table.md
 
-  proof_ci:
-    if: ${{ github.event.pull_request }}
+  proof_ci_cbmc_runner:
+    if: ${{ github.event.repository.owner }} == "FreeRTOS"
     runs-on: cbmc_ubuntu-latest_16-core
+    steps:
+      - name: Set up CBMC runner
+        uses: FreeRTOS/CI-CD-Github-Actions/set_up_cbmc_runner@main
+        with:
+          cbmc_version: "5.61.0"
+          cbmc_viewer_version: "3.5"
+      - name: Run CBMC
+        uses: FreeRTOS/CI-CD-Github-Actions/run_cbmc@main
+        with:
+          proofs_dir: test/cbmc/proofs
+
+  proof_ci_ubuntu_runner:
+    if: ${{ github.event.repository.owner }} != "FreeRTOS"
+    runs-on: ubuntu-20.04
     steps:
       - name: Set up CBMC runner
         uses: FreeRTOS/CI-CD-Github-Actions/set_up_cbmc_runner@main

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ servers.
 This library has gone through code quality checks including verification that no
 function has a
 [GNU Complexity](https://www.gnu.org/software/complexity/manual/complexity.html)
-score over 8, and checks against deviations from mandatory rules in the
+score over 10, and checks against deviations from mandatory rules in the
 [MISRA coding standard](https://www.misra.org.uk). Deviations from the MISRA
 C:2012 guidelines are documented under [MISRA Deviations](MISRA.md). This
 library has also undergone both static code analysis from
@@ -47,20 +47,20 @@ in dependent components.
 
 To clone using HTTPS:
 
-```
+```sh
 git clone https://github.com/FreeRTOS/coreSNTP.git --recurse-submodules
 ```
 
 Using SSH:
 
-```
+```sh
 git clone git@github.com:FreeRTOS/coreSNTP.git --recurse-submodules
 ```
 
 If you have downloaded the repo without using the `--recurse-submodules`
 argument, you need to run:
 
-```
+```sh
 git submodule update --init --recursive
 ```
 
@@ -135,7 +135,7 @@ The Doxygen references were created using Doxygen version 1.9.2. To generate the
 Doxygen pages, please run the following command from the root of this
 repository:
 
-```shell
+```sh
 doxygen docs/doxygen/config.doxyfile
 ```
 

--- a/source/core_sntp_client.c
+++ b/source/core_sntp_client.c
@@ -407,8 +407,7 @@ static SntpStatus_t addClientAuthentication( SntpContext_t * pContext )
     if( status != SntpSuccess )
     {
         LogError( ( "Unable to send time request: Client authentication function failed: "
-                    "RetStatus=%s",
-                    Sntp_StatusToStr( status ) ) );
+                    "RetStatus=%s", Sntp_StatusToStr( status ) ) );
     }
 
     /* Sanity check that the returned authentication data size fits in the remaining space
@@ -714,10 +713,11 @@ static SntpStatus_t processServerResponse( SntpContext_t * pContext,
         {
             /* Server has responded successfully with time, and we have calculated the clock offset
              * of system clock relative to the server.*/
-            LogDebug( ( "Updating system time: ServerTime=%lu %lums ClockOffset=%ldms",
-                        ( unsigned long ) parsedResponse.serverTime.seconds,
-                        ( unsigned long ) FRACTIONS_TO_MS( parsedResponse.serverTime.fractions ),
-                        ( long ) parsedResponse.clockOffsetMs ) );
+            LogDebug( ( "Updating system time: ServerTime=%lu %lums ClockOffset=%lds",
+                    ( unsigned long ) parsedResponse.serverTime.seconds,
+                    ( unsigned long ) FRACTIONS_TO_MS( parsedResponse.serverTime.fractions ),
+                    /* Print out in seconds instead of Ms to account for C90 lack of %lld */
+                    ( long ) parsedResponse.clockOffsetMs / 1000 ) );
 
             /* Update the system clock with the calculated offset. */
             pContext->setTimeFunc( pServer, &parsedResponse.serverTime,
@@ -810,28 +810,31 @@ static bool decideAboutReadRetry( const SntpTimestamp_t * pCurrentTime,
         *pHasResponseTimedOut = true;
 
         LogError( ( "Unable to receive response: Server response has timed out: "
-                    "RequestTime=%lus %lums, TimeoutDuration=%lums, ElapsedTime=%ld",
+                    "RequestTime=%lus %lums, TimeoutDuration=%lums, ElapsedTime=%lus",
                     ( unsigned long ) pRequestTime->seconds,
                     ( unsigned long ) FRACTIONS_TO_MS( pRequestTime->fractions ),
                     ( unsigned long ) responseTimeoutMs,
-                    ( unsigned long ) timeSinceRequestMs ) );
+                    /* Print out in seconds instead of Ms to account for C90 lack of %llu */
+                    ( unsigned long ) ( ( timeSinceRequestMs + 500UL ) / 1000UL ) ) );
     }
     /* Check whether the block time window has expired to determine whether read can be retried. */
     else if( timeElapsedInReadAttempts >= ( uint64_t ) blockTimeMs )
     {
         shouldRetry = false;
         LogDebug( ( "Did not receive server response: Read block time has expired: "
-                    "BlockTime=%lums, ResponseWaitElapsedTime=%lums",
+                    "BlockTime=%lums, ResponseWaitElapsedTime=%lus",
                     ( unsigned long ) blockTimeMs,
-                    ( unsigned long ) timeSinceRequestMs ) );
+                    /* Print out in seconds instead of Ms to account for C90 lack of %llu */
+                    ( unsigned long ) ( ( timeSinceRequestMs + 500UL ) / 1000UL ) ) );
     }
     else
     {
         shouldRetry = true;
         LogDebug( ( "Did not receive server response: Retrying read: "
-                    "BlockTime=%lums, ResponseWaitElapsedTime=%lums, ResponseTimeout=%lu",
+                    "BlockTime=%lums, ResponseWaitElapsedTime=%lus, ResponseTimeout=%lums",
                     ( unsigned long ) blockTimeMs,
-                    ( unsigned long ) timeSinceRequestMs,
+                    /* Print out in seconds instead of Ms to account for C90 lack of %llu */
+                    ( unsigned long ) ( ( timeSinceRequestMs + 500UL ) / 1000UL ),
                     ( unsigned long ) responseTimeoutMs ) );
     }
 

--- a/source/core_sntp_client.c
+++ b/source/core_sntp_client.c
@@ -467,7 +467,7 @@ SntpStatus_t Sntp_SendTimeRequest( SntpContext_t * pContext,
         }
         else
         {
-            LogDebug( ( "Server DNS resolved: Address=0x%08X",
+            LogDebug( ( "Server DNS resolved: Address=0x%08lx",
                         ( unsigned long ) pContext->currentServerAddr ) );
         }
 
@@ -810,17 +810,18 @@ static bool decideAboutReadRetry( const SntpTimestamp_t * pCurrentTime,
         *pHasResponseTimedOut = true;
 
         LogError( ( "Unable to receive response: Server response has timed out: "
-                    "RequestTime=%lus %ums, TimeoutDuration=%lums, ElapsedTime=%ld",
-                    ( unsigned long ) parsedResponse.serverTime.seconds,
-                    ( unsigned long ) FRACTIONS_TO_MS( parsedResponse.serverTime.fractions ),
-                    ( signed long ) parsedResponse.clockOffsetMs ) );
+                    "RequestTime=%lus %lums, TimeoutDuration=%lums, ElapsedTime=%ld",
+                    ( unsigned long ) pRequestTime->seconds,
+                    ( unsigned long ) FRACTIONS_TO_MS( pRequestTime->fractions ),
+                    ( unsigned long ) responseTimeoutMs,
+                    ( unsigned long ) timeSinceRequestMs ) );
     }
     /* Check whether the block time window has expired to determine whether read can be retried. */
     else if( timeElapsedInReadAttempts >= ( uint64_t ) blockTimeMs )
     {
         shouldRetry = false;
         LogDebug( ( "Did not receive server response: Read block time has expired: "
-                    "BlockTime=%ums, ResponseWaitElapsedTime=%lums",
+                    "BlockTime=%lums, ResponseWaitElapsedTime=%lums",
                     ( unsigned long ) blockTimeMs,
                     ( unsigned long ) timeSinceRequestMs ) );
     }

--- a/source/core_sntp_client.c
+++ b/source/core_sntp_client.c
@@ -714,10 +714,10 @@ static SntpStatus_t processServerResponse( SntpContext_t * pContext,
             /* Server has responded successfully with time, and we have calculated the clock offset
              * of system clock relative to the server.*/
             LogDebug( ( "Updating system time: ServerTime=%lu %lums ClockOffset=%lds",
-                    ( unsigned long ) parsedResponse.serverTime.seconds,
-                    ( unsigned long ) FRACTIONS_TO_MS( parsedResponse.serverTime.fractions ),
-                    /* Print out in seconds instead of Ms to account for C90 lack of %lld */
-                    ( long ) parsedResponse.clockOffsetMs / 1000 ) );
+                        ( unsigned long ) parsedResponse.serverTime.seconds,
+                        ( unsigned long ) FRACTIONS_TO_MS( parsedResponse.serverTime.fractions ),
+                        /* Print out in seconds instead of Ms to account for C90 lack of %lld */
+                        ( long ) parsedResponse.clockOffsetMs / 1000 ) );
 
             /* Update the system clock with the calculated offset. */
             pContext->setTimeFunc( pServer, &parsedResponse.serverTime,

--- a/source/core_sntp_client.c
+++ b/source/core_sntp_client.c
@@ -92,8 +92,10 @@ SntpStatus_t Sntp_Init( SntpContext_t * pContext,
     }
     else if( bufferSize < SNTP_PACKET_BASE_SIZE )
     {
-        LogError( ( "Cannot initialize context: Passed network buffer size is less than %u bytes: "
-                    "bufferSize=%lu", SNTP_PACKET_BASE_SIZE, ( unsigned long ) bufferSize ) );
+        LogError( ( "Cannot initialize context: Passed network buffer size is less than %lu bytes: "
+                    "bufferSize=%lu",
+                    ( unsigned long )SNTP_PACKET_BASE_SIZE,
+                    ( unsigned long ) bufferSize ) );
         status = SntpErrorBufferTooSmall;
     }
     else
@@ -324,7 +326,8 @@ static SntpStatus_t sendSntpPacket( const UdpTransportInterface_t * pNetworkIntf
         if( bytesSent < 0 )
         {
             LogError( ( "Unable to send request packet: Transport send failed. "
-                        "ErrorCode=%ld.", ( long int ) bytesSent ) );
+                        "ErrorCode=%ld.",
+                        ( long int ) bytesSent ) );
             status = SntpErrorNetworkFailure;
         }
         else if( bytesSent == 0 )
@@ -343,7 +346,8 @@ static SntpStatus_t sendSntpPacket( const UdpTransportInterface_t * pNetworkIntf
             if( elapsedTimeMs >= timeoutMs )
             {
                 LogError( ( "Unable to send request packet: Timed out retrying send: "
-                            "SendRetryTimeout=%ums", timeoutMs ) );
+                            "SendRetryTimeout=%lums",
+                            ( unsigned long ) timeoutMs ) );
                 status = SntpErrorSendTimeout;
             }
             else
@@ -357,7 +361,9 @@ static SntpStatus_t sendSntpPacket( const UdpTransportInterface_t * pNetworkIntf
         else if( bytesSent != ( int32_t ) packetSize )
         {
             LogError( ( "Unable to send request packet: Transport send returned unexpected bytes sent. "
-                        "ReturnCode=%ld, ExpectedCode=%u", ( long int ) bytesSent, packetSize ) );
+                        "ReturnCode=%ld, ExpectedCode=%u",
+                        ( long int ) bytesSent,
+                        ( unsigned int ) packetSize ) );
 
             status = SntpErrorNetworkFailure;
         }
@@ -401,7 +407,8 @@ static SntpStatus_t addClientAuthentication( SntpContext_t * pContext )
     if( status != SntpSuccess )
     {
         LogError( ( "Unable to send time request: Client authentication function failed: "
-                    "RetStatus=%s", Sntp_StatusToStr( status ) ) );
+                    "RetStatus=%s",
+                    Sntp_StatusToStr( status ) ) );
     }
 
     /* Sanity check that the returned authentication data size fits in the remaining space
@@ -410,7 +417,8 @@ static SntpStatus_t addClientAuthentication( SntpContext_t * pContext )
     {
         LogError( ( "Unable to send time request: Invalid authentication code size: "
                     "AuthCodeSize=%lu, NetworkBufferSize=%lu",
-                    ( unsigned long ) authDataSize, ( unsigned long ) pContext->bufferSize ) );
+                    ( unsigned long ) authDataSize,
+                    ( unsigned long ) pContext->bufferSize ) );
         status = SntpErrorAuthFailure;
     }
     else
@@ -445,20 +453,24 @@ SntpStatus_t Sntp_SendTimeRequest( SntpContext_t * pContext,
          * query. */
         pServer = &pContext->pTimeServers[ pContext->currentServerIndex ];
 
-        LogDebug( ( "Using server %.*s for time query", ( int ) pServer->serverNameLen, pServer->pServerName ) );
+        LogDebug( ( "Using server %.*s for time query",
+                    ( int ) pServer->serverNameLen,
+                    pServer->pServerName ) );
 
         /* Perform DNS resolution of the currently indexed server in the list
          * of configured servers. */
         if( pContext->resolveDnsFunc( pServer, &pContext->currentServerAddr ) == false )
         {
             LogError( ( "Unable to send time request: DNS resolution failed: Server=%.*s",
-                        ( int ) pServer->serverNameLen, pServer->pServerName ) );
+                        ( int ) pServer->serverNameLen,
+                        pServer->pServerName ) );
 
             status = SntpErrorDnsFailure;
         }
         else
         {
-            LogDebug( ( "Server DNS resolved: Address=0x%08X", pContext->currentServerAddr ) );
+            LogDebug( ( "Server DNS resolved: Address=0x%08X",
+                        ( unsigned long ) pContext->currentServerAddr ) );
         }
 
         if( status == SntpSuccess )
@@ -466,8 +478,9 @@ SntpStatus_t Sntp_SendTimeRequest( SntpContext_t * pContext,
             /* Obtain current system time to generate SNTP request packet. */
             pContext->getTimeFunc( &pContext->lastRequestTime );
 
-            LogDebug( ( "Obtained current time for SNTP request packet: Time=%us %ums",
-                        pContext->lastRequestTime.seconds, FRACTIONS_TO_MS( pContext->lastRequestTime.fractions ) ) );
+            LogDebug( ( "Obtained current time for SNTP request packet: Time=%lus %llums",
+                        ( unsigned long ) pContext->lastRequestTime.seconds,
+                        ( unsigned long long ) FRACTIONS_TO_MS( pContext->lastRequestTime.fractions ) ) );
 
             /* Generate SNTP request packet with the current system time and
              * the passed random number. */
@@ -490,8 +503,8 @@ SntpStatus_t Sntp_SendTimeRequest( SntpContext_t * pContext,
 
         if( status == SntpSuccess )
         {
-            LogInfo( ( "Sending serialized SNTP request packet to the server: Addr=%u, Port=%u",
-                       pContext->currentServerAddr,
+            LogInfo( ( "Sending serialized SNTP request packet to the server: Addr=%lu, Port=%u",
+                       ( unsigned long ) pContext->currentServerAddr,
                        pContext->pTimeServers[ pContext->currentServerIndex ].port ) );
 
             /* Send the request packet over the network to the time server. */
@@ -599,7 +612,9 @@ static SntpStatus_t receiveSntpResponse( const UdpTransportInterface_t * pTransp
     else if( bytesRead != ( int32_t ) responseSize )
     {
         LogError( ( "Failed to receive server response: Transport recv returned less than expected bytes."
-                    "ExpectedBytes=%u, ReadBytes=%ld", responseSize, ( long int ) bytesRead ) );
+                    "ExpectedBytes=%u, ReadBytes=%ld",
+                    responseSize,
+                    ( long int ) bytesRead ) );
         status = SntpErrorNetworkFailure;
     }
     else
@@ -652,11 +667,14 @@ static SntpStatus_t processServerResponse( SntpContext_t * pContext,
         if( status != SntpSuccess )
         {
             LogError( ( "Unable to use server response: Server authentication function failed: "
-                        "ReturnStatus=%s", Sntp_StatusToStr( status ) ) );
+                        "ReturnStatus=%s",
+                        Sntp_StatusToStr( status ) ) );
         }
         else
         {
-            LogDebug( ( "Server response has been validated: Server=%.*s", ( int ) pServer->serverNameLen, pServer->pServerName ) );
+            LogDebug( ( "Server response has been validated: Server=%.*s",
+                        ( int ) pServer->serverNameLen,
+                        pServer->pServerName ) );
         }
     }
 
@@ -687,7 +705,9 @@ static SntpStatus_t processServerResponse( SntpContext_t * pContext,
             rotateServerForNextTimeQuery( pContext );
 
             LogError( ( "Unable to use server response: Server has rejected request for time: RejectionCode=%.*s",
-                        ( int ) SNTP_KISS_OF_DEATH_CODE_LENGTH, ( char * ) &parsedResponse.rejectedResponseCode ) );
+                        ( int ) SNTP_KISS_OF_DEATH_CODE_LENGTH,
+                        ( char * ) &parsedResponse.rejectedResponseCode ) );
+
             status = SntpRejectedResponse;
         }
         else if( status == SntpInvalidResponse )
@@ -698,9 +718,10 @@ static SntpStatus_t processServerResponse( SntpContext_t * pContext,
         {
             /* Server has responded successfully with time, and we have calculated the clock offset
              * of system clock relative to the server.*/
-            LogDebug( ( "Updating system time: ServerTime=%u %ums ClockOffset=%lums",
-                        parsedResponse.serverTime.seconds, FRACTIONS_TO_MS( parsedResponse.serverTime.fractions ),
-                        parsedResponse.clockOffsetMs ) );
+            LogDebug( ( "Updating system time: ServerTime=%lu %llums ClockOffset=%lldms",
+                        ( unsigned long ) parsedResponse.serverTime.seconds,
+                        ( unsigned long long ) FRACTIONS_TO_MS( parsedResponse.serverTime.fractions ),
+                        ( long long ) parsedResponse.clockOffsetMs ) );
 
             /* Update the system clock with the calculated offset. */
             pContext->setTimeFunc( pServer, &parsedResponse.serverTime,
@@ -793,24 +814,28 @@ static bool decideAboutReadRetry( const SntpTimestamp_t * pCurrentTime,
         *pHasResponseTimedOut = true;
 
         LogError( ( "Unable to receive response: Server response has timed out: "
-                    "RequestTime=%us %ums, TimeoutDuration=%ums, ElapsedTime=%lu",
-                    pRequestTime->seconds, FRACTIONS_TO_MS( pRequestTime->fractions ),
-                    responseTimeoutMs, timeSinceRequestMs ) );
+                    "RequestTime=%lus %ums, TimeoutDuration=%lums, ElapsedTime=%lld",
+                    ( unsigned long ) parsedResponse.serverTime.seconds,
+                    ( unsigned long ) FRACTIONS_TO_MS( parsedResponse.serverTime.fractions ),
+                    ( signed long long ) parsedResponse.clockOffsetMs ) );
     }
     /* Check whether the block time window has expired to determine whether read can be retried. */
     else if( timeElapsedInReadAttempts >= ( uint64_t ) blockTimeMs )
     {
         shouldRetry = false;
         LogDebug( ( "Did not receive server response: Read block time has expired: "
-                    "BlockTime=%ums, ResponseWaitElapsedTime=%lums",
-                    blockTimeMs, timeSinceRequestMs ) );
+                    "BlockTime=%ums, ResponseWaitElapsedTime=%llums",
+                    ( unsigned long ) blockTimeMs,
+                    ( unsigned long long )timeSinceRequestMs ) );
     }
     else
     {
         shouldRetry = true;
         LogDebug( ( "Did not receive server response: Retrying read: "
-                    "BlockTime=%ums, ResponseWaitElapsedTime=%lums, ResponseTimeout=%u",
-                    blockTimeMs, timeSinceRequestMs, responseTimeoutMs ) );
+                    "BlockTime=%lums, ResponseWaitElapsedTime=%llums, ResponseTimeout=%lu",
+                    ( unsigned long ) blockTimeMs,
+                    ( unsigned long long ) timeSinceRequestMs,
+                    ( unsigned long ) responseTimeoutMs ) );
     }
 
     return shouldRetry;

--- a/source/core_sntp_client.c
+++ b/source/core_sntp_client.c
@@ -454,16 +454,14 @@ SntpStatus_t Sntp_SendTimeRequest( SntpContext_t * pContext,
         pServer = &pContext->pTimeServers[ pContext->currentServerIndex ];
 
         LogDebug( ( "Using server %.*s for time query",
-                    ( int ) pServer->serverNameLen,
-                    pServer->pServerName ) );
+                    ( int ) pServer->serverNameLen, pServer->pServerName ) );
 
         /* Perform DNS resolution of the currently indexed server in the list
          * of configured servers. */
         if( pContext->resolveDnsFunc( pServer, &pContext->currentServerAddr ) == false )
         {
             LogError( ( "Unable to send time request: DNS resolution failed: Server=%.*s",
-                        ( int ) pServer->serverNameLen,
-                        pServer->pServerName ) );
+                        ( int ) pServer->serverNameLen, pServer->pServerName ) );
 
             status = SntpErrorDnsFailure;
         }
@@ -478,9 +476,9 @@ SntpStatus_t Sntp_SendTimeRequest( SntpContext_t * pContext,
             /* Obtain current system time to generate SNTP request packet. */
             pContext->getTimeFunc( &pContext->lastRequestTime );
 
-            LogDebug( ( "Obtained current time for SNTP request packet: Time=%lus %llums",
+            LogDebug( ( "Obtained current time for SNTP request packet: Time=%lus %lums",
                         ( unsigned long ) pContext->lastRequestTime.seconds,
-                        ( unsigned long long ) FRACTIONS_TO_MS( pContext->lastRequestTime.fractions ) ) );
+                        ( unsigned long ) FRACTIONS_TO_MS( pContext->lastRequestTime.fractions ) ) );
 
             /* Generate SNTP request packet with the current system time and
              * the passed random number. */
@@ -667,14 +665,12 @@ static SntpStatus_t processServerResponse( SntpContext_t * pContext,
         if( status != SntpSuccess )
         {
             LogError( ( "Unable to use server response: Server authentication function failed: "
-                        "ReturnStatus=%s",
-                        Sntp_StatusToStr( status ) ) );
+                        "ReturnStatus=%s", Sntp_StatusToStr( status ) ) );
         }
         else
         {
             LogDebug( ( "Server response has been validated: Server=%.*s",
-                        ( int ) pServer->serverNameLen,
-                        pServer->pServerName ) );
+                        ( int ) pServer->serverNameLen, pServer->pServerName ) );
         }
     }
 
@@ -718,10 +714,10 @@ static SntpStatus_t processServerResponse( SntpContext_t * pContext,
         {
             /* Server has responded successfully with time, and we have calculated the clock offset
              * of system clock relative to the server.*/
-            LogDebug( ( "Updating system time: ServerTime=%lu %llums ClockOffset=%lldms",
+            LogDebug( ( "Updating system time: ServerTime=%lu %lums ClockOffset=%ldms",
                         ( unsigned long ) parsedResponse.serverTime.seconds,
-                        ( unsigned long long ) FRACTIONS_TO_MS( parsedResponse.serverTime.fractions ),
-                        ( long long ) parsedResponse.clockOffsetMs ) );
+                        ( unsigned long ) FRACTIONS_TO_MS( parsedResponse.serverTime.fractions ),
+                        ( long ) parsedResponse.clockOffsetMs ) );
 
             /* Update the system clock with the calculated offset. */
             pContext->setTimeFunc( pServer, &parsedResponse.serverTime,
@@ -814,27 +810,27 @@ static bool decideAboutReadRetry( const SntpTimestamp_t * pCurrentTime,
         *pHasResponseTimedOut = true;
 
         LogError( ( "Unable to receive response: Server response has timed out: "
-                    "RequestTime=%lus %ums, TimeoutDuration=%lums, ElapsedTime=%lld",
+                    "RequestTime=%lus %ums, TimeoutDuration=%lums, ElapsedTime=%ld",
                     ( unsigned long ) parsedResponse.serverTime.seconds,
                     ( unsigned long ) FRACTIONS_TO_MS( parsedResponse.serverTime.fractions ),
-                    ( signed long long ) parsedResponse.clockOffsetMs ) );
+                    ( signed long ) parsedResponse.clockOffsetMs ) );
     }
     /* Check whether the block time window has expired to determine whether read can be retried. */
     else if( timeElapsedInReadAttempts >= ( uint64_t ) blockTimeMs )
     {
         shouldRetry = false;
         LogDebug( ( "Did not receive server response: Read block time has expired: "
-                    "BlockTime=%ums, ResponseWaitElapsedTime=%llums",
+                    "BlockTime=%ums, ResponseWaitElapsedTime=%lums",
                     ( unsigned long ) blockTimeMs,
-                    ( unsigned long long ) timeSinceRequestMs ) );
+                    ( unsigned long ) timeSinceRequestMs ) );
     }
     else
     {
         shouldRetry = true;
         LogDebug( ( "Did not receive server response: Retrying read: "
-                    "BlockTime=%lums, ResponseWaitElapsedTime=%llums, ResponseTimeout=%lu",
+                    "BlockTime=%lums, ResponseWaitElapsedTime=%lums, ResponseTimeout=%lu",
                     ( unsigned long ) blockTimeMs,
-                    ( unsigned long long ) timeSinceRequestMs,
+                    ( unsigned long ) timeSinceRequestMs,
                     ( unsigned long ) responseTimeoutMs ) );
     }
 

--- a/source/core_sntp_client.c
+++ b/source/core_sntp_client.c
@@ -94,7 +94,7 @@ SntpStatus_t Sntp_Init( SntpContext_t * pContext,
     {
         LogError( ( "Cannot initialize context: Passed network buffer size is less than %lu bytes: "
                     "bufferSize=%lu",
-                    ( unsigned long )SNTP_PACKET_BASE_SIZE,
+                    ( unsigned long ) SNTP_PACKET_BASE_SIZE,
                     ( unsigned long ) bufferSize ) );
         status = SntpErrorBufferTooSmall;
     }
@@ -826,7 +826,7 @@ static bool decideAboutReadRetry( const SntpTimestamp_t * pCurrentTime,
         LogDebug( ( "Did not receive server response: Read block time has expired: "
                     "BlockTime=%ums, ResponseWaitElapsedTime=%llums",
                     ( unsigned long ) blockTimeMs,
-                    ( unsigned long long )timeSinceRequestMs ) );
+                    ( unsigned long long ) timeSinceRequestMs ) );
     }
     else
     {


### PR DESCRIPTION
Description
-----------
Change the logging casts to use the correct types, where possible.
Fix a signed integer that was being printed as an unsigned integer

C90 does not support `long long`, so cast the 64 bit values to a 32 bit one for now.
The values stored in the 64 bit variables that are used for logging are milliseconds.
Swap these to printing out in seconds to reduce the chance of these overflowing.
While this is not a true fix of the issue, I believe it should cover most use cases because"
    * The millisecond value int32_t max value has is 596 hours.
    * The millisecond value uint32_t max value has is 1193 hours.
    * The variable used is for a response from a server.
    * A response from a server 24 or 48 days later should be rare enough that hopefully this truncation in a log message can be forgiven
    
Added a message pointing out that we were are converting the milliseconds to seconds in an attempt to reduce the chance of this happening however.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
#76 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
