### PR TITLE
Include all SntpStatus_t values in Sntp_StatusToStr

### DIFF
--- a/.github/.cSpellWords.txt
+++ b/.github/.cSpellWords.txt
@@ -23,6 +23,7 @@ lcov
 ldms
 lums
 misra
+nondet
 sinclude
 sntp
 utest

--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -9,8 +9,8 @@
     </tr>
     <tr>
         <td>core_sntp_client.c</td>
-        <td><center>1.5K</center></td>
-        <td><center>1.2K</center></td>
+        <td><center>1.7K</center></td>
+        <td><center>1.4K</center></td>
     </tr>
     <tr>
         <td>core_sntp_serializer.c</td>
@@ -19,7 +19,7 @@
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>2.5K</center></b></td>
-        <td><b><center>2.0K</center></b></td>
+        <td><b><center>2.7K</center></b></td>
+        <td><b><center>2.2K</center></b></td>
     </tr>
 </table>

--- a/source/core_sntp_client.c
+++ b/source/core_sntp_client.c
@@ -931,6 +931,10 @@ const char * Sntp_StatusToStr( SntpStatus_t status )
             pString = "SntpErrorBadParameter";
             break;
 
+        case SntpRejectedResponse:
+            pString = "SntpRejectedResponse";
+            break;
+
         case SntpRejectedResponseChangeServer:
             pString = "SntpRejectedResponseChangeServer";
             break;
@@ -973,6 +977,22 @@ const char * Sntp_StatusToStr( SntpStatus_t status )
 
         case SntpErrorAuthFailure:
             pString = "SntpErrorAuthFailure";
+            break;
+
+        case SntpErrorSendTimeout:
+            pString = "SntpErrorSendTimeout";
+            break;
+
+        case SntpErrorResponseTimeout:
+            pString = "SntpErrorResponseTimeout";
+            break;
+
+        case SntpNoResponseReceived:
+            pString = "SntpNoResponseReceived";
+            break;
+
+        case SntpErrorContextNotInitialized:
+            pString = "SntpErrorContextNotInitialized";
             break;
 
         default:

--- a/test/unit-test/core_sntp_client_utest.c
+++ b/test/unit-test/core_sntp_client_utest.c
@@ -1367,6 +1367,7 @@ void test_StatusToStr( void )
 {
     TEST_ASSERT_EQUAL_STRING( "SntpSuccess", Sntp_StatusToStr( SntpSuccess ) );
     TEST_ASSERT_EQUAL_STRING( "SntpErrorBadParameter", Sntp_StatusToStr( SntpErrorBadParameter ) );
+    TEST_ASSERT_EQUAL_STRING( "SntpRejectedResponse", Sntp_StatusToStr( SntpRejectedResponse ) );
     TEST_ASSERT_EQUAL_STRING( "SntpRejectedResponseChangeServer", Sntp_StatusToStr( SntpRejectedResponseChangeServer ) );
     TEST_ASSERT_EQUAL_STRING( "SntpRejectedResponseRetryWithBackoff", Sntp_StatusToStr( SntpRejectedResponseRetryWithBackoff ) );
     TEST_ASSERT_EQUAL_STRING( "SntpRejectedResponseOtherCode", Sntp_StatusToStr( SntpRejectedResponseOtherCode ) );
@@ -1378,5 +1379,10 @@ void test_StatusToStr( void )
     TEST_ASSERT_EQUAL_STRING( "SntpErrorNetworkFailure", Sntp_StatusToStr( SntpErrorNetworkFailure ) );
     TEST_ASSERT_EQUAL_STRING( "SntpServerNotAuthenticated", Sntp_StatusToStr( SntpServerNotAuthenticated ) );
     TEST_ASSERT_EQUAL_STRING( "SntpErrorAuthFailure", Sntp_StatusToStr( SntpErrorAuthFailure ) );
+    TEST_ASSERT_EQUAL_STRING( "SntpErrorSendTimeout", Sntp_StatusToStr( SntpErrorSendTimeout ) );
+    TEST_ASSERT_EQUAL_STRING( "SntpErrorResponseTimeout", Sntp_StatusToStr( SntpErrorResponseTimeout ) );
+    TEST_ASSERT_EQUAL_STRING( "SntpNoResponseReceived", Sntp_StatusToStr( SntpNoResponseReceived ) );
+    TEST_ASSERT_EQUAL_STRING( "SntpErrorContextNotInitialized", Sntp_StatusToStr( SntpErrorContextNotInitialized ) );
+
     TEST_ASSERT_EQUAL_STRING( "Invalid status code!", Sntp_StatusToStr( 100 ) );
 }


### PR DESCRIPTION

Description
-----------

Withtout this change, the function Sntp_StatusToStr would return "Invalid status code!" for the following valid status codes:

- SntpRejectedResponse
- SntpErrorSendTimeout
- SntpErrorResponseTimeout
- SntpNoResponseReceived
- SntpErrorContextNotInitialized

Test Steps
-----------
Unit tests pass. 

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/FreeRTOS/coreSNTP/issues/82

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
