### PR TITLE
Fix MISRA C 2012 deviations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \
-          -DBUILD_UNIT_TESTS=ON \
+          -DUNITTEST=ON \
           -DCMAKE_C_FLAGS="${CFLAGS}"
           make -C build all -j8
 
@@ -84,7 +84,7 @@ jobs:
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \
-          -DBUILD_UNIT_TESTS=ON \
+          -DUNITTEST=ON \
           -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -Wno-error=pedantic -Wno-variadic-macros -DLOGGING_LEVEL_DEBUG=1'
           make -C build/ all
 

--- a/source/core_sntp_client.c
+++ b/source/core_sntp_client.c
@@ -675,7 +675,7 @@ static SntpStatus_t processServerResponse( SntpContext_t * pContext,
 
     if( status == SntpSuccess )
     {
-        SntpResponseData_t parsedResponse;
+        SntpResponseData_t parsedResponse = { 0 };
 
         /* De-serialize response packet to determine whether the server accepted or rejected
          * the request for time. Also, calculate the system clock offset if the server responded

--- a/source/core_sntp_serializer.c
+++ b/source/core_sntp_serializer.c
@@ -246,9 +246,9 @@ static uint32_t readWordFromNetworkByteOrderMemory( const uint32_t * ptr )
 
     assert( ptr != NULL );
 
-    return ( uint32_t ) ( ( ( uint32_t ) pMemStartByte[ 0 ] << 24 ) |
-                          ( 0x00FF0000U & ( ( uint32_t ) pMemStartByte[ 1 ] << 16 ) ) |
-                          ( 0x0000FF00U & ( ( uint32_t ) pMemStartByte[ 2 ] << 8 ) ) |
+    return ( uint32_t ) ( ( ( ( uint32_t ) pMemStartByte[ 0 ] ) << 24 ) |
+                          ( 0x00FF0000U & ( ( ( uint32_t ) pMemStartByte[ 1 ] ) << 16 ) ) |
+                          ( 0x0000FF00U & ( ( ( uint32_t ) pMemStartByte[ 2 ] ) << 8 ) ) |
                           ( ( uint32_t ) pMemStartByte[ 3 ] ) );
 }
 

--- a/source/core_sntp_serializer.c
+++ b/source/core_sntp_serializer.c
@@ -221,12 +221,14 @@ typedef struct SntpPacket
 static void fillWordMemoryInNetworkOrder( uint32_t * pWordMemory,
                                           uint32_t data )
 {
+    uint8_t * pByteMemory = ( uint8_t * ) pWordMemory;
+
     assert( pWordMemory != NULL );
 
-    *( ( uint8_t * ) pWordMemory ) = ( uint8_t ) ( data >> 24 );
-    *( ( uint8_t * ) pWordMemory + 1 ) = ( uint8_t ) ( ( data >> 16 ) & 0x000000FFU );
-    *( ( uint8_t * ) pWordMemory + 2 ) = ( uint8_t ) ( ( data >> 8 ) & 0x000000FFU );
-    *( ( uint8_t * ) pWordMemory + 3 ) = ( uint8_t ) ( ( data ) & 0x000000FFU );
+    pByteMemory[ 0 ] = ( uint8_t ) ( data >> 24 );
+    pByteMemory[ 1 ] = ( uint8_t ) ( ( data >> 16 ) & 0x000000FFU );
+    pByteMemory[ 2 ] = ( uint8_t ) ( ( data >> 8 ) & 0x000000FFU );
+    pByteMemory[ 3 ] = ( uint8_t ) ( ( data ) & 0x000000FFU );
 }
 
 /**
@@ -244,10 +246,10 @@ static uint32_t readWordFromNetworkByteOrderMemory( const uint32_t * ptr )
 
     assert( ptr != NULL );
 
-    return ( uint32_t ) ( ( ( uint32_t ) *( pMemStartByte ) << 24 ) |
-                          ( 0x00FF0000U & ( ( uint32_t ) *( pMemStartByte + 1 ) << 16 ) ) |
-                          ( 0x0000FF00U & ( ( uint32_t ) *( pMemStartByte + 2 ) << 8 ) ) |
-                          ( ( uint32_t ) *( pMemStartByte + 3 ) ) );
+    return ( uint32_t ) ( ( ( uint32_t ) pMemStartByte[ 0 ] << 24 ) |
+                          ( 0x00FF0000U & ( ( uint32_t ) pMemStartByte[ 1 ] << 16 ) ) |
+                          ( 0x0000FF00U & ( ( uint32_t ) pMemStartByte[ 2 ] << 8 ) ) |
+                          ( ( uint32_t ) pMemStartByte[ 3 ] ) );
 }
 
 /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required( VERSION 3.13.0 )
 project( "coreSNTP tests"
+         VERSION 1.2.0
          LANGUAGES C )
 
 # Allow the project to be organized into folders.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required( VERSION 3.13.0 )
-project( "coreSNTP unit test"
+project( "coreSNTP tests"
          LANGUAGES C )
 
 # Allow the project to be organized into folders.
@@ -8,6 +8,13 @@ set_property( GLOBAL PROPERTY USE_FOLDERS ON )
 # Use C90.
 set( CMAKE_C_STANDARD 90 )
 set( CMAKE_C_STANDARD_REQUIRED ON )
+
+# If no configuration is defined, turn everything on.
+if( NOT DEFINED COV_ANALYSIS AND NOT DEFINED UNITTEST AND NOT DEFINED BUILD_CODE_EXAMPLE )
+    set( COV_ANALYSIS ON )
+    set( UNITTEST ON )
+    set( BUILD_CODE_EXAMPLE ON )
+endif()
 
 # Do not allow in-source build.
 if( ${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR} )
@@ -30,42 +37,51 @@ set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )
 set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
 set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
 
-# ================================ Coverity Analysis Configuration =================================
-
 # Include filepaths for source and include.
 include( ${MODULE_ROOT_DIR}/coreSntpFilePaths.cmake )
 
-# Target for Coverity analysis that builds the library.
-add_library( coverity_analysis
-             ${CORE_SNTP_SOURCES} )
+# ================================ Coverity Analysis Configuration =================================
 
-# Add coreSNTP library public include path.
-target_include_directories( coverity_analysis
-                            PUBLIC
-                             ${CORE_SNTP_INCLUDE_PUBLIC_DIRS} )
+if( COV_ANALYSIS )
 
-# Build SNTP library target without custom config dependency.
-target_compile_definitions( coverity_analysis PUBLIC SNTP_DO_NOT_USE_CUSTOM_CONFIG=1 )
+    # Target for Coverity analysis that builds the library.
+    add_library( coverity_analysis
+                 ${CORE_SNTP_SOURCES} )
 
-# Build without debug enabled when performing static analysis
-target_compile_options(coverity_analysis PUBLIC -DNDEBUG )
+    # Add coreSNTP library public include path.
+    target_include_directories( coverity_analysis
+                                PUBLIC
+                                ${CORE_SNTP_INCLUDE_PUBLIC_DIRS} )
+
+    # Build SNTP library target without custom config dependency.
+    target_compile_definitions( coverity_analysis PUBLIC SNTP_DO_NOT_USE_CUSTOM_CONFIG=1 )
+
+    # Build without debug enabled when performing static analysis
+    target_compile_options(coverity_analysis PUBLIC -DNDEBUG )
+endif()
 
 #  ==================================== Code Example Build ====================================
 
-if(${BUILD_CODE_EXAMPLE})
+if( BUILD_CODE_EXAMPLE )
     # Target for Coverity analysis that builds the library.
     add_executable( code_example_posix
+                    ${CORE_SNTP_SOURCES}
                     ${MODULE_ROOT_DIR}/docs/doxygen/code_examples/example_sntp_client_posix.c )
 
-    # Add coreSNTP library public include path.
-    target_link_libraries( code_example_posix
-                            coverity_analysis )
+    target_include_directories( code_example_posix
+                                PUBLIC
+                                ${CORE_SNTP_INCLUDE_PUBLIC_DIRS} )
 
+    # Build SNTP library target without custom config dependency.
+    target_compile_definitions( code_example_posix PUBLIC SNTP_DO_NOT_USE_CUSTOM_CONFIG=1 )
+
+    # Build without debug enabled when performing static analysis
+    target_compile_options( code_example_posix PUBLIC -DNDEBUG )
 endif()
 
 #  ==================================== Unit Test Configuration ====================================
 
-if(${BUILD_UNIT_TESTS})
+if( UNITTEST )
     # Include CMock build configuration.
     include( unit-test/cmock_build.cmake )
 

--- a/tools/coverity/misra.config
+++ b/tools/coverity/misra.config
@@ -1,30 +1,27 @@
-// MISRA C-2012 Rules
-
 {
-    version : "2.0",
-    standard : "c2012",
-    title: "Coverity MISRA Configuration",
-    deviations : [
-        // Disable the following rules.
+    "version" : "2.0",
+    "standard" : "c2012",
+    "title" : "Coverity MISRA Configuration",
+    "deviations" : [
         {
-            deviation: "Directive 4.9",
-            reason: "Allow inclusion of function like macros. Asserts and logging are done using function like macros."
+            "deviation": "Directive 4.9",
+            "reason": "Allow inclusion of function like macros. Asserts and logging are done using function like macros."
         },
         {
-            deviation: "Rule 2.4",
-            reason: "Allow unused tags. Some compilers warn if types are not tagged."
+            "deviation": "Rule 2.4",
+            "reason": "Allow unused tags. Some compilers warn if types are not tagged."
         },
         {
-            deviation: "Rule 2.5",
-            reason: "Allow unused macros. coreSNTP Library headers define macros intended for the application's use, but are not used by the agent."
+            "deviation": "Rule 2.5",
+            "reason": "Allow unused macros. coreSNTP Library headers define macros intended for the application's use, but are not used by the agent."
         },
         {
-            deviation: "Rule 3.1",
-            reason: "Allow nested comments. Documentation blocks contain comments for example code."
+            "deviation": "Rule 3.1",
+            "reason": "Allow nested comments. Documentation blocks contain comments for example code."
         },
         {
-            deviation: "Rule 8.7",
-            reason: "API functions are not used by library. They must be externally visible in order to be used by the application."
-        },
+            "deviation": "Rule 8.7",
+            "reason": "API functions are not used by library. They must be externally visible in order to be used by the application."
+        }
     ]
 }


### PR DESCRIPTION
Description
-----------
* Fix rule 18.6 deviations. Not to operaters on pointer.
* Fix rule 9.1 deviations. Initialize the local variable to prevent use of uninitialized variable.


Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
