### PR TITLE
Fix doxygen documentation of SntpLeapSecondInfo_t

### DIFF
--- a/source/include/core_sntp_serializer.h
+++ b/source/include/core_sntp_serializer.h
@@ -263,10 +263,10 @@ typedef enum SntpStatus
  */
 typedef enum SntpLeapSecondInfo
 {
-    NoLeapSecond = 0x00,              /** <@brief There is no upcoming leap second adjustment. */
-    LastMinuteHas61Seconds = 0x01,    /** <@brief A leap second should be inserted in the last minute before midnight. */
-    LastMinuteHas59Seconds = 0x02,    /** <@brief A leap second should be deleted from the last minute before midnight. */
-    AlarmServerNotSynchronized = 0x03 /** <@brief An alarm condition meaning that server's time is not synchronized
+    NoLeapSecond = 0x00,              /**< @brief There is no upcoming leap second adjustment. */
+    LastMinuteHas61Seconds = 0x01,    /**< @brief A leap second should be inserted in the last minute before midnight. */
+    LastMinuteHas59Seconds = 0x02,    /**< @brief A leap second should be deleted from the last minute before midnight. */
+    AlarmServerNotSynchronized = 0x03 /**< @brief An alarm condition meaning that server's time is not synchronized
                                        * to an upstream NTP (or SNTP) server. */
 } SntpLeapSecondInfo_t;
 


### PR DESCRIPTION
Description
-----------
Fix doxygen documentation of SntpLeapSecondInfo_t.

Test Steps
-----------
Before:

<img width="413" alt="Before" src="https://github.com/FreeRTOS/coreSNTP/assets/33462878/73a455df-97b0-4d32-a6b0-93993eb0dae6">

After:

<img width="546" alt="After" src="https://github.com/FreeRTOS/coreSNTP/assets/33462878/7b363aa7-3199-4da8-8579-a62ba9617c0f">

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [NA] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/FreeRTOS/coreSNTP/issues/91

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
