### PR TITLE
Replace Synopsys link with blackduck one to solve link error.

### DIFF
--- a/tools/coverity/README.md
+++ b/tools/coverity/README.md
@@ -12,7 +12,7 @@ see the [MISRA.md](https://github.com/FreeRTOS/coreSNTP/blob/main/MISRA.md) file
 
 ## Getting Started
 ### Prerequisites
-You can run this on a platform supported by Coverity. The list and other details can be found [here](https://sig-docs.synopsys.com/polaris/topics/c_coverity-compatible-platforms.html).
+You can run this on a platform supported by Coverity. The list and other details can be found [here](Replace Synopsys link with blackduck one to solve link error.).
 To compile and run the Coverity target successfully, you must have the following:
 
 1. CMake version > 3.13.0 (You can check whether you have this by typing `cmake --version`)

--- a/tools/coverity/README.md
+++ b/tools/coverity/README.md
@@ -12,7 +12,7 @@ see the [MISRA.md](https://github.com/FreeRTOS/coreSNTP/blob/main/MISRA.md) file
 
 ## Getting Started
 ### Prerequisites
-You can run this on a platform supported by Coverity. The list and other details can be found [here](Replace Synopsys link with blackduck one to solve link error.).
+You can run this on a platform supported by Coverity. The list and other details can be found [here](https://documentation.blackduck.com/bundle/coverity-docs/page/deploy-install-guide/topics/supported_platforms_for_coverity_analysis.html).
 To compile and run the Coverity target successfully, you must have the following:
 
 1. CMake version > 3.13.0 (You can check whether you have this by typing `cmake --version`)


### PR DESCRIPTION
Replace Synopsys link with blackduck one to solve link error.

Description
-----------
A link error found on [Synopsis website](https://sig-docs.synopsys.com/polaris/topics/c_coverity-compatible-platforms.html). Replace that with [blackduck one](https://documentation.blackduck.com/bundle/coverity-docs/page/deploy-install-guide/topics/supported_platforms_for_coverity_analysis.html).

Test Steps
-----------
NA

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
