### PR TITLE
Remove unwanted comment  for return value of SntpGetTime_t

### DIFF
--- a/source/include/core_sntp_client.h
+++ b/source/include/core_sntp_client.h
@@ -100,9 +100,6 @@ typedef bool ( * SntpResolveDns_t )( const SntpServerInfo_t * pServerAddr,
  *
  * @param[out] pCurrentTime This should be filled with the current system time
  * in SNTP timestamp format.
- *
- * @return `true` if obtaining system time is successful; otherwise `false` to
- * represent failure.
  */
 typedef void ( * SntpGetTime_t )( SntpTimestamp_t * pCurrentTime );
 

--- a/tools/coverity/README.md
+++ b/tools/coverity/README.md
@@ -12,7 +12,7 @@ see the [MISRA.md](https://github.com/FreeRTOS/coreSNTP/blob/main/MISRA.md) file
 
 ## Getting Started
 ### Prerequisites
-You can run this on a platform supported by Coverity. The list and other details can be found [here](https://sig-docs.synopsys.com/polaris/topics/c_coverity-compatible-platforms.html).
+You can run this on a platform supported by Coverity. The list and other details can be found [here](https://documentation.blackduck.com/bundle/coverity-docs/page/deploy-install-guide/topics/supported_platforms_for_coverity_analysis.html).
 To compile and run the Coverity target successfully, you must have the following:
 
 1. CMake version > 3.13.0 (You can check whether you have this by typing `cmake --version`)


### PR DESCRIPTION
Description
-----------
This PR removes the comment from the declaration of `SntpGetTime_t` since this is a void function.

Test Steps
-----------
NA

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] <s>I have tested my changes. No regression in existing tests.</s>
- [ ] <s>I have modified and/or added unit-tests to cover the code changes in this Pull Request.</s>

Related Issue
-----------
#100 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
